### PR TITLE
TRIVIAGEN-8: Navigation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,8 +1,11 @@
+import org.jetbrains.kotlin.config.JvmAnalysisFlags.useIR
+
 plugins {
     id("com.android.application") version "8.4.0"
     kotlin("android") version "1.9.0"
     id("kotlin-kapt")
     id("com.google.dagger.hilt.android")
+    id("org.jetbrains.kotlin.plugin.serialization") version "1.9.0"
 }
 
 android {
@@ -60,11 +63,13 @@ val espressoCoreVersion by extra("3.5.1")
 val lifecycleRuntimeKtxVersion by extra("2.8.0")
 val activityComposeVersion by extra("1.9.0")
 val composeBomVersion by extra("2023.08.00")
-val hiltVersion by extra("2.51")
+val hiltVersion by extra("2.51.1")
 val coroutineVersion by extra("1.7.1")
 val retrofitVersion by extra("2.9.0")
 val moshiVersion by extra("1.15.1")
 val moshiConverter by extra("2.9.0")
+val composeNavigation by extra("2.8.0-beta02")
+val serialization by extra("1.6.3")
 
 dependencies {
     implementation(platform("androidx.compose:compose-bom:$composeBomVersion"))
@@ -105,4 +110,8 @@ dependencies {
     kapt("com.squareup.moshi:moshi-kotlin-codegen:$moshiVersion")
     implementation("com.squareup.moshi:moshi-adapters:$moshiVersion")
     implementation("com.squareup.retrofit2:adapter-rxjava2:$retrofitVersion")
+
+    // Navigation
+    implementation("androidx.navigation:navigation-compose:$composeNavigation")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$serialization")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -112,4 +112,5 @@ dependencies {
     // Navigation
     implementation("androidx.navigation:navigation-compose:$composeNavigation")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$serialization")
+    androidTestImplementation("androidx.navigation:navigation-testing:2.7.7")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.config.JvmAnalysisFlags.useIR
-
 plugins {
     id("com.android.application") version "8.4.0"
     kotlin("android") version "1.9.0"

--- a/app/src/androidTest/java/com/triviagenai/triviagen/NavigationTest.kt
+++ b/app/src/androidTest/java/com/triviagenai/triviagen/NavigationTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.navigation.compose.ComposeNavigator
 import androidx.navigation.testing.TestNavHostController
+import com.triviagenai.triviagen.core.presentation.navigation.NavGraph
 import com.triviagenai.triviagen.core.presentation.navigation.Route
 import org.junit.Before
 import org.junit.Rule
@@ -27,7 +28,7 @@ class NavigationTest {
                 ComposeNavigator()
             )
             
-            TriviaNavigation(navController = navController, startDestination = Route.MainMenuRoute)
+            NavGraph(navController = navController, startDestination = Route.MainMenuRoute)
         }
     }
 

--- a/app/src/androidTest/java/com/triviagenai/triviagen/NavigationTest.kt
+++ b/app/src/androidTest/java/com/triviagenai/triviagen/NavigationTest.kt
@@ -1,0 +1,81 @@
+package com.triviagenai.triviagen
+
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.testing.TestNavHostController
+import com.triviagenai.triviagen.core.presentation.Route
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class NavigationTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    lateinit var navController: TestNavHostController
+
+    @Before
+    fun setup() {
+        composeTestRule.setContent {
+            navController = TestNavHostController(LocalContext.current)
+            navController.navigatorProvider.addNavigator(
+                ComposeNavigator()
+            )
+            
+            TriviaNavigation(navController = navController, startDestination = Route.MainMenuRoute)
+        }
+    }
+
+    @Test
+    fun verifyStartDestination() {
+        composeTestRule
+            .onNodeWithContentDescription("MainMenuScreen")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun navigation_clickQuickGame_navigatesToRoundSetup() {
+        composeTestRule
+            .onNodeWithText("Quick game")
+            .performClick()
+
+        composeTestRule
+            .onNodeWithContentDescription("RoundSetupScreen")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun navigation_clickStartRound_navigatesToTriviaGame() {
+        composeTestRule
+            .onNodeWithText("Quick game")
+            .performClick()
+
+        composeTestRule
+            .onNodeWithText("Start Round")
+            .performClick()
+
+        composeTestRule
+            .onNodeWithContentDescription("TriviaGameScreen")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun navigation_clickRandomRound_navigatesToTriviaGame() {
+        composeTestRule
+            .onNodeWithText("Quick game")
+            .performClick()
+
+        composeTestRule
+            .onNodeWithText("Random Round")
+            .performClick()
+
+        composeTestRule
+            .onNodeWithContentDescription("TriviaGameScreen")
+            .assertIsDisplayed()
+    }
+}

--- a/app/src/androidTest/java/com/triviagenai/triviagen/NavigationTest.kt
+++ b/app/src/androidTest/java/com/triviagenai/triviagen/NavigationTest.kt
@@ -18,7 +18,7 @@ class NavigationTest {
     @get:Rule
     val composeTestRule = createComposeRule()
 
-    lateinit var navController: TestNavHostController
+    private lateinit var navController: TestNavHostController
 
     @Before
     fun setup() {

--- a/app/src/androidTest/java/com/triviagenai/triviagen/NavigationTest.kt
+++ b/app/src/androidTest/java/com/triviagenai/triviagen/NavigationTest.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.navigation.compose.ComposeNavigator
 import androidx.navigation.testing.TestNavHostController
-import com.triviagenai.triviagen.core.presentation.Route
+import com.triviagenai.triviagen.core.presentation.navigation.Route
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/app/src/main/java/com/triviagenai/triviagen/MainActivity.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/MainActivity.kt
@@ -3,9 +3,10 @@ package com.triviagenai.triviagen
 import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.activity.ComponentActivity
-import androidx.activity.R
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -17,7 +18,6 @@ import com.triviagenai.triviagen.trivia.presentation.roundsetup.RoundSetupScreen
 import com.triviagenai.triviagen.trivia.presentation.triviagame.TriviaGameScreen
 import com.triviagenai.triviagen.ui.theme.TriviaGenTheme
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.serialization.Serializable
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -29,31 +29,42 @@ class MainActivity : ComponentActivity() {
             TriviaGenTheme {
                 val navController = rememberNavController()
 
-                NavHost(
+                TriviaNavigation(
                     navController = navController,
                     startDestination = Route.MainMenuRoute
-                ) {
-                    composable<Route.MainMenuRoute> {
-                        MainMenuScreen(navController = navController)
-                    }
-
-                    composable<Route.RoundSetupRoute> {
-                        RoundSetupScreen(navController = navController)
-                    }
-
-                    composable<Route.TriviaGameRoute> {
-                        TriviaGameScreen(navController = navController)
-                    }
-
-                    composable<Route.ResultsRoute> {
-                        ResultsScreen(navController = navController)
-                    }
-
-                    composable<Route.AnswersRoute> {
-                        AnswersScreen(navController = navController)
-                    }
-                }
+                )
             }
+        }
+    }
+}
+
+@Composable
+fun TriviaNavigation(
+    navController: NavHostController,
+    startDestination: Route
+) {
+    NavHost(
+        navController = navController,
+        startDestination = startDestination
+    ) {
+        composable<Route.MainMenuRoute> {
+            MainMenuScreen(navController = navController)
+        }
+
+        composable<Route.RoundSetupRoute> {
+            RoundSetupScreen(navController = navController)
+        }
+
+        composable<Route.TriviaGameRoute> {
+            TriviaGameScreen(navController = navController)
+        }
+
+        composable<Route.ResultsRoute> {
+            ResultsScreen(navController = navController)
+        }
+
+        composable<Route.AnswersRoute> {
+            AnswersScreen(navController = navController)
         }
     }
 }

--- a/app/src/main/java/com/triviagenai/triviagen/MainActivity.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/MainActivity.kt
@@ -5,17 +5,9 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.runtime.Composable
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import com.triviagenai.triviagen.core.presentation.Route
-import com.triviagenai.triviagen.trivia.presentation.answers.AnswersScreen
-import com.triviagenai.triviagen.trivia.presentation.mainmenu.MainMenuScreen
-import com.triviagenai.triviagen.trivia.presentation.results.ResultsScreen
-import com.triviagenai.triviagen.trivia.presentation.roundsetup.RoundSetupScreen
-import com.triviagenai.triviagen.trivia.presentation.triviagame.TriviaGameScreen
+import com.triviagenai.triviagen.core.presentation.navigation.NavGraph
+import com.triviagenai.triviagen.core.presentation.navigation.Route
 import com.triviagenai.triviagen.ui.theme.TriviaGenTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -29,42 +21,11 @@ class MainActivity : ComponentActivity() {
             TriviaGenTheme {
                 val navController = rememberNavController()
 
-                TriviaNavigation(
+                NavGraph(
                     navController = navController,
                     startDestination = Route.MainMenuRoute
                 )
             }
-        }
-    }
-}
-
-@Composable
-fun TriviaNavigation(
-    navController: NavHostController,
-    startDestination: Route
-) {
-    NavHost(
-        navController = navController,
-        startDestination = startDestination
-    ) {
-        composable<Route.MainMenuRoute> {
-            MainMenuScreen(navController = navController)
-        }
-
-        composable<Route.RoundSetupRoute> {
-            RoundSetupScreen(navController = navController)
-        }
-
-        composable<Route.TriviaGameRoute> {
-            TriviaGameScreen(navController = navController)
-        }
-
-        composable<Route.ResultsRoute> {
-            ResultsScreen(navController = navController)
-        }
-
-        composable<Route.AnswersRoute> {
-            AnswersScreen(navController = navController)
         }
     }
 }

--- a/app/src/main/java/com/triviagenai/triviagen/MainActivity.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/MainActivity.kt
@@ -3,11 +3,13 @@ package com.triviagenai.triviagen
 import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.R
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.triviagenai.triviagen.core.presentation.Route
 import com.triviagenai.triviagen.trivia.presentation.answers.AnswersScreen
 import com.triviagenai.triviagen.trivia.presentation.mainmenu.MainMenuScreen
 import com.triviagenai.triviagen.trivia.presentation.results.ResultsScreen
@@ -29,25 +31,25 @@ class MainActivity : ComponentActivity() {
 
                 NavHost(
                     navController = navController,
-                    startDestination = MainManuRoute
+                    startDestination = Route.MainMenuRoute
                 ) {
-                    composable<MainManuRoute> {
+                    composable<Route.MainMenuRoute> {
                         MainMenuScreen(navController = navController)
                     }
 
-                    composable<RoundSetupRoute> {
+                    composable<Route.RoundSetupRoute> {
                         RoundSetupScreen(navController = navController)
                     }
 
-                    composable<TriviaGameRoute> {
+                    composable<Route.TriviaGameRoute> {
                         TriviaGameScreen(navController = navController)
                     }
 
-                    composable<ResultsRoute> {
+                    composable<Route.ResultsRoute> {
                         ResultsScreen(navController = navController)
                     }
 
-                    composable<AnswersRoute> {
+                    composable<Route.AnswersRoute> {
                         AnswersScreen(navController = navController)
                     }
                 }
@@ -55,18 +57,3 @@ class MainActivity : ComponentActivity() {
         }
     }
 }
-
-@Serializable
-object MainManuRoute
-
-@Serializable
-object RoundSetupRoute
-
-@Serializable
-object TriviaGameRoute
-
-@Serializable
-object ResultsRoute
-
-@Serializable
-object AnswersRoute

--- a/app/src/main/java/com/triviagenai/triviagen/MainActivity.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/MainActivity.kt
@@ -5,9 +5,17 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.triviagenai.triviagen.trivia.presentation.answers.AnswersScreen
+import com.triviagenai.triviagen.trivia.presentation.mainmenu.MainMenuScreen
 import com.triviagenai.triviagen.trivia.presentation.results.ResultsScreen
+import com.triviagenai.triviagen.trivia.presentation.roundsetup.RoundSetupScreen
+import com.triviagenai.triviagen.trivia.presentation.triviagame.TriviaGameScreen
 import com.triviagenai.triviagen.ui.theme.TriviaGenTheme
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.serialization.Serializable
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -17,8 +25,48 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             TriviaGenTheme {
-                ResultsScreen()
+                val navController = rememberNavController()
+
+                NavHost(
+                    navController = navController,
+                    startDestination = MainManuRoute
+                ) {
+                    composable<MainManuRoute> {
+                        MainMenuScreen(navController = navController)
+                    }
+
+                    composable<RoundSetupRoute> {
+                        RoundSetupScreen(navController = navController)
+                    }
+
+                    composable<TriviaGameRoute> {
+                        TriviaGameScreen(navController = navController)
+                    }
+
+                    composable<ResultsRoute> {
+                        ResultsScreen(navController = navController)
+                    }
+
+                    composable<AnswersRoute> {
+                        AnswersScreen(navController = navController)
+                    }
+                }
             }
         }
     }
 }
+
+@Serializable
+object MainManuRoute
+
+@Serializable
+object RoundSetupRoute
+
+@Serializable
+object TriviaGameRoute
+
+@Serializable
+object ResultsRoute
+
+@Serializable
+object AnswersRoute

--- a/app/src/main/java/com/triviagenai/triviagen/core/data/api/TriviaGenApiService.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/core/data/api/TriviaGenApiService.kt
@@ -1,7 +1,6 @@
 package com.triviagenai.triviagen.core.data.api
 
 import com.triviagenai.triviagen.trivia.data.model.Round
-import com.triviagenai.triviagen.trivia.domain.model.TriviaQuestion
 import retrofit2.http.GET
 import retrofit2.http.Query
 

--- a/app/src/main/java/com/triviagenai/triviagen/core/di/NetworkModule.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/core/di/NetworkModule.kt
@@ -40,7 +40,7 @@ object NetworkModule {
             .build()
         return Retrofit.Builder()
             // If running backend locally use device IP
-            .baseUrl("http://192.168.0.38:8080")
+            .baseUrl("http://<your-ip-address>:8080")
             .addConverterFactory(MoshiConverterFactory.create(moshi))
             .client(okHttpClient)
             .build()

--- a/app/src/main/java/com/triviagenai/triviagen/core/presentation/ButtonData.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/core/presentation/ButtonData.kt
@@ -1,0 +1,6 @@
+package com.triviagenai.triviagen.core.presentation
+
+data class ButtonData(
+    val text: String,
+    val onClick: () -> Unit
+)

--- a/app/src/main/java/com/triviagenai/triviagen/core/presentation/Route.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/core/presentation/Route.kt
@@ -1,0 +1,20 @@
+package com.triviagenai.triviagen.core.presentation
+
+import kotlinx.serialization.Serializable
+
+sealed class Route {
+    @Serializable
+    data object MainMenuRoute : Route()
+
+    @Serializable
+    data object RoundSetupRoute : Route()
+
+    @Serializable
+    data object TriviaGameRoute : Route()
+
+    @Serializable
+    data object ResultsRoute : Route()
+
+    @Serializable
+    data object AnswersRoute : Route()
+}

--- a/app/src/main/java/com/triviagenai/triviagen/core/presentation/TriviaGenScaffold.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/core/presentation/TriviaGenScaffold.kt
@@ -21,13 +21,13 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.triviagenai.triviagen.R
+import com.triviagenai.triviagen.core.presentation.navigation.NavigationStatus
 import com.triviagenai.triviagen.ui.theme.RoyalPurple
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TriviaGenScaffold(
-    backNavigationIcon: Boolean = false,
-    navController: NavController? = null,
+    navigationStatus: NavigationStatus,
     content: @Composable () -> Unit
 ) {
     Scaffold(
@@ -39,10 +39,10 @@ fun TriviaGenScaffold(
                     )
                 },
                 navigationIcon = {
-                    if(backNavigationIcon) {
+                    if(navigationStatus is NavigationStatus.Enabled) {
                         IconButton(
                             onClick = {
-                                navController?.popBackStack()
+                                navigationStatus.navController.popBackStack()
                             },
                         ) {
                             Icon(

--- a/app/src/main/java/com/triviagenai/triviagen/core/presentation/TriviaGenScaffold.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/core/presentation/TriviaGenScaffold.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
 import com.triviagenai.triviagen.R
 import com.triviagenai.triviagen.ui.theme.RoyalPurple
 
@@ -26,6 +27,7 @@ import com.triviagenai.triviagen.ui.theme.RoyalPurple
 @Composable
 fun TriviaGenScaffold(
     backNavigationIcon: Boolean = false,
+    navController: NavController? = null,
     content: @Composable () -> Unit
 ) {
     Scaffold(
@@ -40,7 +42,7 @@ fun TriviaGenScaffold(
                     if(backNavigationIcon) {
                         IconButton(
                             onClick = {
-
+                                navController?.popBackStack()
                             },
                         ) {
                             Icon(

--- a/app/src/main/java/com/triviagenai/triviagen/core/presentation/TriviaGenScaffold.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/core/presentation/TriviaGenScaffold.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
 import com.triviagenai.triviagen.R
 import com.triviagenai.triviagen.core.presentation.navigation.NavigationStatus
 import com.triviagenai.triviagen.ui.theme.RoyalPurple

--- a/app/src/main/java/com/triviagenai/triviagen/core/presentation/navigation/NavGraph.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/core/presentation/navigation/NavGraph.kt
@@ -24,7 +24,11 @@ fun NavGraph(
         startDestination = startDestination
     ) {
         composable<Route.MainMenuRoute> {
-            MainMenuScreen(navController = navController)
+            MainMenuScreen(
+                navController = navController,
+                triviaQuestionViewModel = triviaQuestionViewModel
+            )
+
         }
 
         composable<Route.RoundSetupRoute> {

--- a/app/src/main/java/com/triviagenai/triviagen/core/presentation/navigation/NavGraph.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/core/presentation/navigation/NavGraph.kt
@@ -25,10 +25,8 @@ fun NavGraph(
     ) {
         composable<Route.MainMenuRoute> {
             MainMenuScreen(
-                navController = navController,
-                triviaQuestionViewModel = triviaQuestionViewModel
+                navController = navController
             )
-
         }
 
         composable<Route.RoundSetupRoute> {

--- a/app/src/main/java/com/triviagenai/triviagen/core/presentation/navigation/NavGraph.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/core/presentation/navigation/NavGraph.kt
@@ -1,0 +1,42 @@
+package com.triviagenai.triviagen.core.presentation.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import com.triviagenai.triviagen.trivia.presentation.answers.AnswersScreen
+import com.triviagenai.triviagen.trivia.presentation.mainmenu.MainMenuScreen
+import com.triviagenai.triviagen.trivia.presentation.results.ResultsScreen
+import com.triviagenai.triviagen.trivia.presentation.roundsetup.RoundSetupScreen
+import com.triviagenai.triviagen.trivia.presentation.triviagame.TriviaGameScreen
+
+@Composable
+fun NavGraph(
+    navController: NavHostController,
+    startDestination: Route
+) {
+    NavHost(
+        navController = navController,
+        startDestination = startDestination
+    ) {
+        composable<Route.MainMenuRoute> {
+            MainMenuScreen(navController = navController)
+        }
+
+        composable<Route.RoundSetupRoute> {
+            RoundSetupScreen(navController = navController)
+        }
+
+        composable<Route.TriviaGameRoute> {
+            TriviaGameScreen(navController = navController)
+        }
+
+        composable<Route.ResultsRoute> {
+            ResultsScreen(navController = navController)
+        }
+
+        composable<Route.AnswersRoute> {
+            AnswersScreen(navController = navController)
+        }
+    }
+}

--- a/app/src/main/java/com/triviagenai/triviagen/core/presentation/navigation/NavigationStatus.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/core/presentation/navigation/NavigationStatus.kt
@@ -1,0 +1,8 @@
+package com.triviagenai.triviagen.core.presentation.navigation
+
+import androidx.navigation.NavController
+
+sealed class NavigationStatus {
+    object None : NavigationStatus()
+    data class Enabled(val navController: NavController) : NavigationStatus()
+}

--- a/app/src/main/java/com/triviagenai/triviagen/core/presentation/navigation/Route.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/core/presentation/navigation/Route.kt
@@ -1,4 +1,4 @@
-package com.triviagenai.triviagen.core.presentation
+package com.triviagenai.triviagen.core.presentation.navigation
 
 import kotlinx.serialization.Serializable
 

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/TriviaQuestionViewModel.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/TriviaQuestionViewModel.kt
@@ -79,26 +79,22 @@ class TriviaQuestionViewModel @Inject constructor(
 
     fun processIntent(intent: TriviaIntent) {
         when (intent) {
-            is TriviaIntent.SubmitAnswer -> viewModelScope.launch { submitAnswer(intent.selectedOptionIndex, intent.navController) }
+            is TriviaIntent.SubmitAnswer -> viewModelScope.launch { submitAnswer(intent.selectedOptionIndex) }
             TriviaIntent.RandomTriviaRound -> fetchRandomTriviaRoundQuestions()
         }
     }
 
-    private fun nextQuestion(navController: NavHostController) {
+    private fun nextQuestion() {
         val currentState = uiState.value
         if (currentState is TriviaUIState.Success) {
             val nextIndex = currentState.currentQuestionIndex + 1
             if (nextIndex < currentState.questions.size) {
                 _uiState.value = currentState.copy(currentQuestionIndex = nextIndex)
-            } else {
-                navController.navigate(Route.ResultsRoute) {
-                    popUpTo(Route.TriviaGameRoute) { inclusive = true }
-                }
             }
         }
     }
 
-    private suspend fun submitAnswer(selectedOptionIndex: Int, navController: NavHostController) {
+    private suspend fun submitAnswer(selectedOptionIndex: Int) {
         isOptionButtonEnabled = false
         val currentState = _uiState.value
         if (currentState is TriviaUIState.Success) {
@@ -114,7 +110,7 @@ class TriviaQuestionViewModel @Inject constructor(
                     currentState.copy(score = currentState.score + POINTS)
             }
             delay(2000)
-            nextQuestion(navController)
+            nextQuestion()
             isOptionButtonEnabled = true
         }
     }

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/TriviaQuestionViewModel.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/TriviaQuestionViewModel.kt
@@ -1,5 +1,8 @@
 package com.triviagenai.triviagen.trivia.presentation
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavHostController
@@ -41,13 +44,15 @@ class TriviaQuestionViewModel @Inject constructor(
     }
 
     private val _uiState = MutableStateFlow<TriviaUIState>(TriviaUIState.Loading)
-
     val uiState: StateFlow<TriviaUIState> = _uiState
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5000),
             initialValue = TriviaUIState.Loading
         )
+
+    var isOptionButtonEnabled by mutableStateOf(true)
+        private set
 
     fun fetchTriviaQuestions(topic: String) {
         viewModelScope.launch {
@@ -92,6 +97,7 @@ class TriviaQuestionViewModel @Inject constructor(
     }
 
     private suspend fun submitAnswer(selectedOptionIndex: Int, navController: NavHostController) {
+        isOptionButtonEnabled = false
         val currentState = _uiState.value
         if (currentState is TriviaUIState.Success) {
             val currentQuestion = currentState.questions[currentState.currentQuestionIndex]
@@ -107,6 +113,7 @@ class TriviaQuestionViewModel @Inject constructor(
             }
             delay(2000)
             nextQuestion(navController)
+            isOptionButtonEnabled = true
         }
     }
 }

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/TriviaQuestionViewModel.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/TriviaQuestionViewModel.kt
@@ -8,7 +8,6 @@ import androidx.core.app.ActivityCompat.finishAffinity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavHostController
-import com.triviagenai.triviagen.core.presentation.navigation.Route
 import com.triviagenai.triviagen.trivia.domain.model.SelectedAnswerState
 import com.triviagenai.triviagen.trivia.domain.usecase.GetTriviaQuestionsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/TriviaQuestionViewModel.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/TriviaQuestionViewModel.kt
@@ -1,10 +1,8 @@
 package com.triviagenai.triviagen.trivia.presentation
 
-import android.app.Activity
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.core.app.ActivityCompat.finishAffinity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavHostController
@@ -112,11 +110,6 @@ class TriviaQuestionViewModel @Inject constructor(
             nextQuestion()
             isOptionButtonEnabled = true
         }
-    }
-
-
-    fun exitApp(activity: Activity) {
-        finishAffinity(activity)
     }
 }
 

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/TriviaQuestionViewModel.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/TriviaQuestionViewModel.kt
@@ -1,8 +1,10 @@
 package com.triviagenai.triviagen.trivia.presentation
 
+import android.app.Activity
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.core.app.ActivityCompat.finishAffinity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavHostController
@@ -115,6 +117,11 @@ class TriviaQuestionViewModel @Inject constructor(
             nextQuestion(navController)
             isOptionButtonEnabled = true
         }
+    }
+
+
+    fun exitApp(activity: Activity) {
+        finishAffinity(activity)
     }
 }
 

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/answers/AnswersScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/answers/AnswersScreen.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.navigation.NavHostController
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
 import com.triviagenai.triviagen.trivia.domain.model.TriviaQuestion
@@ -25,6 +27,7 @@ fun AnswersScreen(navController: NavHostController) {
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
                 .fillMaxSize()
+                .semantics { contentDescription = "AnswersScreen" }
         ) {
             items(trivias.size) { index ->
                 TriviaAnswerCard(trivias[index])

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/answers/AnswersScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/answers/AnswersScreen.kt
@@ -5,12 +5,13 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
 import com.triviagenai.triviagen.trivia.domain.model.TriviaQuestion
 import com.triviagenai.triviagen.trivia.presentation.answers.components.TriviaAnswerCard
 
 @Composable
-fun AnswersScreen() {
+fun AnswersScreen(navController: NavHostController) {
     val trivias = listOf(
         TriviaQuestion("What?", listOf("1", "2"), 0),
         TriviaQuestion("What?", listOf("1", "2"), 0),

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/answers/AnswersScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/answers/AnswersScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.navigation.NavHostController
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
+import com.triviagenai.triviagen.core.presentation.navigation.NavigationStatus
 import com.triviagenai.triviagen.trivia.presentation.TriviaQuestionViewModel
 import com.triviagenai.triviagen.trivia.presentation.TriviaUIState
 import com.triviagenai.triviagen.trivia.presentation.answers.components.TriviaAnswerCard
@@ -28,8 +29,7 @@ fun AnswersScreen(
     }
 
     TriviaGenScaffold(
-        backNavigationIcon = true,
-        navController = navController
+        navigationStatus = NavigationStatus.Enabled(navController)
     ) {
         LazyColumn(
             horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/answers/AnswersScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/answers/AnswersScreen.kt
@@ -7,8 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.platform.testTag
 import androidx.navigation.NavHostController
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
 import com.triviagenai.triviagen.trivia.presentation.TriviaQuestionViewModel
@@ -36,7 +35,7 @@ fun AnswersScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
                 .fillMaxSize()
-                .semantics { contentDescription = "AnswersScreen" }
+                .testTag("AnswersScreen")
         ) {
             if(trivia.isEmpty()) {
                 item {

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/answers/AnswersScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/answers/AnswersScreen.kt
@@ -13,11 +13,14 @@ import com.triviagenai.triviagen.trivia.presentation.answers.components.TriviaAn
 @Composable
 fun AnswersScreen(navController: NavHostController) {
     val trivias = listOf(
-        TriviaQuestion("What?", listOf("1", "2"), 0),
-        TriviaQuestion("What?", listOf("1", "2"), 0),
+        TriviaQuestion("What is the largest animal?", listOf("Option", "Correct answer", "Option", "Wrong answer"), 1),
+        TriviaQuestion("When was the prehistory?", listOf("1", "2", "Never", "Tomorrow"), 0),
     )
 
-    TriviaGenScaffold(backNavigationIcon = true) {
+    TriviaGenScaffold(
+        backNavigationIcon = true,
+        navController = navController
+    ) {
         LazyColumn(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/answers/components/TriviaAnswerCard.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/answers/components/TriviaAnswerCard.kt
@@ -50,7 +50,7 @@ fun TriviaAnswerCard(triviaQuestion: TriviaQuestion) {
 
             val checkedOption = 1 //TODO replace with state with real user answer. This value is for testing only.
 
-            for (i in 0..3) {
+            for (i in 0..triviaQuestion.options.lastIndex) {
                 Text(
                     text = triviaQuestion.options[i],
                     modifier = Modifier
@@ -71,7 +71,6 @@ fun TriviaAnswerCard(triviaQuestion: TriviaQuestion) {
                 )
                 Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.padding_small)))
             }
-
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.padding_small)))
         }
     }

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/mainmenu/MainMenuScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/mainmenu/MainMenuScreen.kt
@@ -24,12 +24,10 @@ import com.triviagenai.triviagen.core.presentation.ButtonData
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
 import com.triviagenai.triviagen.core.presentation.navigation.NavigationStatus
 import com.triviagenai.triviagen.core.presentation.navigation.Route
-import com.triviagenai.triviagen.trivia.presentation.TriviaQuestionViewModel
 
 @Composable
 fun MainMenuScreen(
-    navController: NavHostController,
-    triviaQuestionViewModel: TriviaQuestionViewModel
+    navController: NavHostController
 ) {
     val activity = LocalContext.current as Activity
 
@@ -72,7 +70,7 @@ fun MainMenuScreen(
                 ButtonData(
                     text = stringResource(R.string.exit),
                     onClick = {
-                        triviaQuestionViewModel.exitApp(activity)
+                        activity.finishAffinity()
                     }
                 )
             )

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/mainmenu/MainMenuScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/mainmenu/MainMenuScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -44,6 +45,9 @@ fun MainMenuScreen(
                 contentDescription = "App logo",
                 modifier = Modifier
                     .size(dimensionResource(id = R.dimen.element_large))
+                    .padding(
+                        top = dimensionResource(id = R.dimen.padding_large),
+                    )
             )
 
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.spacer_medium)))
@@ -73,9 +77,13 @@ fun MainMenuScreen(
 
             for(buttonData in textButtonsData) {
                 TextButton(
-                    onClick = buttonData.onClick
+                    onClick = buttonData.onClick,
+                    modifier = Modifier
+                        .padding(dimensionResource(id = R.dimen.padding_small))
                 ) {
-                    Text(buttonData.text)
+                    Text(
+                        buttonData.text
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/mainmenu/MainMenuScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/mainmenu/MainMenuScreen.kt
@@ -22,6 +22,7 @@ import androidx.navigation.NavHostController
 import com.triviagenai.triviagen.R
 import com.triviagenai.triviagen.core.presentation.ButtonData
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
+import com.triviagenai.triviagen.core.presentation.navigation.NavigationStatus
 import com.triviagenai.triviagen.core.presentation.navigation.Route
 import com.triviagenai.triviagen.trivia.presentation.TriviaQuestionViewModel
 
@@ -32,7 +33,9 @@ fun MainMenuScreen(
 ) {
     val activity = LocalContext.current as Activity
 
-    TriviaGenScaffold {
+    TriviaGenScaffold(
+        navigationStatus = NavigationStatus.None
+    ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/mainmenu/MainMenuScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/mainmenu/MainMenuScreen.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavHostController
 import com.triviagenai.triviagen.MainActivity
 import com.triviagenai.triviagen.R
-import com.triviagenai.triviagen.RoundSetupRoute
+import com.triviagenai.triviagen.core.presentation.Route
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
 
 @Composable
@@ -41,7 +41,7 @@ fun MainMenuScreen(navController: NavHostController) {
             TextButton(
                 onClick = {
                     navController.navigate(
-                        RoundSetupRoute
+                        Route.RoundSetupRoute
                     )
                 }
             ) {

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/mainmenu/MainMenuScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/mainmenu/MainMenuScreen.kt
@@ -15,12 +15,14 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavHostController
 import com.triviagenai.triviagen.MainActivity
 import com.triviagenai.triviagen.R
+import com.triviagenai.triviagen.RoundSetupRoute
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
 
 @Composable
-fun MainMenuScreen() {
+fun MainMenuScreen(navController: NavHostController) {
     TriviaGenScaffold {
         Column(
             modifier = Modifier
@@ -37,7 +39,11 @@ fun MainMenuScreen() {
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.spacer_medium)))
             
             TextButton(
-                onClick = { /*navigates to the trivia screen*/ }
+                onClick = {
+                    navController.navigate(
+                        RoundSetupRoute
+                    )
+                }
             ) {
                 Text(stringResource(R.string.quick_game))
             }

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/mainmenu/MainMenuScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/mainmenu/MainMenuScreen.kt
@@ -1,6 +1,7 @@
 package com.triviagenai.triviagen.trivia.presentation.mainmenu
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -15,6 +16,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.navigation.NavHostController
 import com.triviagenai.triviagen.MainActivity
 import com.triviagenai.triviagen.R
@@ -26,7 +29,8 @@ fun MainMenuScreen(navController: NavHostController) {
     TriviaGenScaffold {
         Column(
             modifier = Modifier
-                .fillMaxSize(),
+                .fillMaxSize()
+                .semantics { contentDescription = "MainMenuScreen" },
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Image(
@@ -35,9 +39,9 @@ fun MainMenuScreen(navController: NavHostController) {
                 modifier = Modifier
                     .size(dimensionResource(id = R.dimen.element_large))
             )
-            
+
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.spacer_medium)))
-            
+
             TextButton(
                 onClick = {
                     navController.navigate(
@@ -54,13 +58,11 @@ fun MainMenuScreen(navController: NavHostController) {
                 Text(stringResource(R.string.options))
             }
 
-            val activity = LocalContext.current as MainActivity
-
             TextButton(
-                onClick = { activity.finish() }
+                onClick = {  } //TODO: This approach is wrong because crush when running navigation tests: val activity = LocalContext.current as MainActivity; activity.finish()
             ) {
                 Text(stringResource(R.string.exit))
             }
         }
-     }
+    }
 }

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/mainmenu/MainMenuScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/mainmenu/MainMenuScreen.kt
@@ -1,7 +1,6 @@
 package com.triviagenai.triviagen.trivia.presentation.mainmenu
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,16 +11,14 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.navigation.NavHostController
-import com.triviagenai.triviagen.MainActivity
 import com.triviagenai.triviagen.R
-import com.triviagenai.triviagen.core.presentation.Route
+import com.triviagenai.triviagen.core.presentation.navigation.Route
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
 
 @Composable

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/mainmenu/MainMenuScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/mainmenu/MainMenuScreen.kt
@@ -14,11 +14,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.navigation.NavHostController
 import com.triviagenai.triviagen.R
 import com.triviagenai.triviagen.core.presentation.ButtonData
@@ -37,7 +36,7 @@ fun MainMenuScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .semantics { contentDescription = "MainMenuScreen" },
+                .testTag("MainMenuScreen"),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Image(

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/mainmenu/MainMenuScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/mainmenu/MainMenuScreen.kt
@@ -1,5 +1,6 @@
 package com.triviagenai.triviagen.trivia.presentation.mainmenu
 
+import android.app.Activity
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -11,6 +12,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -18,11 +20,18 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.navigation.NavHostController
 import com.triviagenai.triviagen.R
-import com.triviagenai.triviagen.core.presentation.navigation.Route
+import com.triviagenai.triviagen.core.presentation.ButtonData
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
+import com.triviagenai.triviagen.core.presentation.navigation.Route
+import com.triviagenai.triviagen.trivia.presentation.TriviaQuestionViewModel
 
 @Composable
-fun MainMenuScreen(navController: NavHostController) {
+fun MainMenuScreen(
+    navController: NavHostController,
+    triviaQuestionViewModel: TriviaQuestionViewModel
+) {
+    val activity = LocalContext.current as Activity
+
     TriviaGenScaffold {
         Column(
             modifier = Modifier
@@ -39,26 +48,35 @@ fun MainMenuScreen(navController: NavHostController) {
 
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.spacer_medium)))
 
-            TextButton(
-                onClick = {
-                    navController.navigate(
-                        Route.RoundSetupRoute
-                    )
+            val textButtonsData = listOf(
+                ButtonData(
+                    text = stringResource(R.string.quick_game),
+                    onClick = {
+                        navController.navigate(
+                            Route.RoundSetupRoute
+                        )
+                    }
+                ),
+                ButtonData(
+                    text = stringResource(R.string.options),
+                    onClick = {
+                        //TODO: navigate to options screen
+                    }
+                ),
+                ButtonData(
+                    text = stringResource(R.string.exit),
+                    onClick = {
+                        triviaQuestionViewModel.exitApp(activity)
+                    }
+                )
+            )
+
+            for(buttonData in textButtonsData) {
+                TextButton(
+                    onClick = buttonData.onClick
+                ) {
+                    Text(buttonData.text)
                 }
-            ) {
-                Text(stringResource(R.string.quick_game))
-            }
-
-            TextButton(
-                onClick = { /*navigates to the options screen*/ }
-            ) {
-                Text(stringResource(R.string.options))
-            }
-
-            TextButton(
-                onClick = {  } //TODO: This approach is wrong because crush when running navigation tests: val activity = LocalContext.current as MainActivity; activity.finish()
-            ) {
-                Text(stringResource(R.string.exit))
             }
         }
     }

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/results/ResultsScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/results/ResultsScreen.kt
@@ -22,6 +22,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
@@ -37,7 +39,8 @@ fun ResultsScreen(navController: NavHostController) {
     TriviaGenScaffold {
         Column(
             modifier = Modifier
-                .fillMaxSize(),
+                .fillMaxSize()
+                .semantics { contentDescription = "ResultsScreen" },
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/results/ResultsScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/results/ResultsScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import com.triviagenai.triviagen.R
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
+import com.triviagenai.triviagen.core.presentation.navigation.NavigationStatus
 import com.triviagenai.triviagen.core.presentation.navigation.Route
 import com.triviagenai.triviagen.trivia.presentation.TriviaQuestionViewModel
 import com.triviagenai.triviagen.trivia.presentation.TriviaUIState
@@ -60,7 +61,9 @@ fun ResultsScreen(
         }
     }
 
-    TriviaGenScaffold {
+    TriviaGenScaffold(
+        navigationStatus = NavigationStatus.None
+    ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/results/ResultsScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/results/ResultsScreen.kt
@@ -25,7 +25,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
+import com.triviagenai.triviagen.AnswersRoute
+import com.triviagenai.triviagen.MainManuRoute
 import com.triviagenai.triviagen.R
+import com.triviagenai.triviagen.RoundSetupRoute
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
 import com.triviagenai.triviagen.ui.theme.RoyalPurple
 
@@ -58,7 +61,7 @@ fun ResultsScreen(navController: NavHostController) {
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.spacer_medium)))
 
             OutlinedButton(
-                onClick = { /*TODO*/ },
+                onClick = { navController.navigate(AnswersRoute) },
                 shape = AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner)),
                 modifier = Modifier
                     .padding(dimensionResource(id = R.dimen.padding_small))
@@ -80,11 +83,11 @@ fun ResultsScreen(navController: NavHostController) {
             val buttonData = listOf(
                 ButtonData(
                     text = stringResource(R.string.retry),
-                    onClick = { /*TODO*/ }
+                    onClick = { navController.navigate(RoundSetupRoute) }
                 ),
                 ButtonData(
                     text = stringResource(R.string.home),
-                    onClick = { /*TODO*/ }
+                    onClick = { navController.navigate(MainManuRoute) }
                 )
             )
 

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/results/ResultsScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/results/ResultsScreen.kt
@@ -24,12 +24,13 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
 import com.triviagenai.triviagen.R
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
 import com.triviagenai.triviagen.ui.theme.RoyalPurple
 
 @Composable
-fun ResultsScreen() {
+fun ResultsScreen(navController: NavHostController) {
     val score = 0.51f
 
     TriviaGenScaffold {

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/results/ResultsScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/results/ResultsScreen.kt
@@ -25,10 +25,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
-import com.triviagenai.triviagen.AnswersRoute
-import com.triviagenai.triviagen.MainManuRoute
 import com.triviagenai.triviagen.R
-import com.triviagenai.triviagen.RoundSetupRoute
+import com.triviagenai.triviagen.core.presentation.Route
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
 import com.triviagenai.triviagen.ui.theme.RoyalPurple
 
@@ -61,7 +59,7 @@ fun ResultsScreen(navController: NavHostController) {
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.spacer_medium)))
 
             OutlinedButton(
-                onClick = { navController.navigate(AnswersRoute) },
+                onClick = { navController.navigate(Route.AnswersRoute) },
                 shape = AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner)),
                 modifier = Modifier
                     .padding(dimensionResource(id = R.dimen.padding_small))
@@ -83,11 +81,11 @@ fun ResultsScreen(navController: NavHostController) {
             val buttonData = listOf(
                 ButtonData(
                     text = stringResource(R.string.retry),
-                    onClick = { navController.navigate(RoundSetupRoute) }
+                    onClick = { navController.navigate(Route.RoundSetupRoute) }
                 ),
                 ButtonData(
                     text = stringResource(R.string.home),
-                    onClick = { navController.navigate(MainManuRoute) }
+                    onClick = { navController.navigate(Route.MainMenuRoute) }
                 )
             )
 

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/results/ResultsScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/results/ResultsScreen.kt
@@ -19,10 +19,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
@@ -65,7 +64,7 @@ fun ResultsScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .semantics { contentDescription = "ResultsScreen" },
+                .testTag("ResultsScreen"),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/results/ResultsScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/results/ResultsScreen.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import com.triviagenai.triviagen.R
-import com.triviagenai.triviagen.core.presentation.Route
+import com.triviagenai.triviagen.core.presentation.navigation.Route
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
 import com.triviagenai.triviagen.ui.theme.RoyalPurple
 

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/results/components/NavigationButtons.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/results/components/NavigationButtons.kt
@@ -13,16 +13,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.navigation.NavHostController
 import com.triviagenai.triviagen.R
+import com.triviagenai.triviagen.core.presentation.ButtonData
 import com.triviagenai.triviagen.core.presentation.navigation.Route
 import com.triviagenai.triviagen.ui.theme.RoyalPurple
 
 @Composable
 fun NavigationButtons(navController: NavHostController) {
-    data class ButtonData(
-        val text: String,
-        val onClick: () -> Unit
-    )
-
     val buttonData = listOf(
         ButtonData(
             text = stringResource(R.string.retry),

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/results/components/TriviaScoreIndicator.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/results/components/TriviaScoreIndicator.kt
@@ -33,7 +33,7 @@ fun TriviaScoreIndicator(
         )
 
         Text(
-            text = "Score: ${(score).toInt()}"
+            text = "Score: ${(score).toInt()}/${TriviaQuestionViewModel.POINTS * questionsSize}"
         )
     }
     Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.spacer_medium)))

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/roundsetup/RoundSetupScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/roundsetup/RoundSetupScreen.kt
@@ -19,10 +19,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
@@ -47,7 +46,7 @@ fun RoundSetupScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .semantics { contentDescription = "RoundSetupScreen" },
+                .testTag("RoundSetupScreen"),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/roundsetup/RoundSetupScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/roundsetup/RoundSetupScreen.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import com.triviagenai.triviagen.R
-import com.triviagenai.triviagen.core.presentation.Route
+import com.triviagenai.triviagen.core.presentation.navigation.Route
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
 import com.triviagenai.triviagen.ui.theme.RoyalPurple
 

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/roundsetup/RoundSetupScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/roundsetup/RoundSetupScreen.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import com.triviagenai.triviagen.R
-import com.triviagenai.triviagen.TriviaGameRoute
+import com.triviagenai.triviagen.core.presentation.Route
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
 import com.triviagenai.triviagen.ui.theme.RoyalPurple
 
@@ -64,7 +64,7 @@ fun RoundSetupScreen(navController: NavHostController) {
             )
 
             ElevatedButton(
-                onClick = { navController.navigate(TriviaGameRoute) },
+                onClick = { navController.navigate(Route.TriviaGameRoute) },
                 shape = AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner)),
                 modifier = Modifier
                     .padding(dimensionResource(id = R.dimen.padding_small))
@@ -85,7 +85,7 @@ fun RoundSetupScreen(navController: NavHostController) {
             )
 
             ElevatedButton(
-                onClick = { navController.navigate(TriviaGameRoute) },
+                onClick = { navController.navigate(Route.TriviaGameRoute) },
                 shape = AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner)),
                 modifier = Modifier
                     .padding(dimensionResource(id = R.dimen.padding_small))

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/roundsetup/RoundSetupScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/roundsetup/RoundSetupScreen.kt
@@ -21,6 +21,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
@@ -39,7 +41,8 @@ fun RoundSetupScreen(navController: NavHostController) {
     ) {
         Column(
             modifier = Modifier
-                .fillMaxSize(),
+                .fillMaxSize()
+                .semantics { contentDescription = "RoundSetupScreen" },
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/roundsetup/RoundSetupScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/roundsetup/RoundSetupScreen.kt
@@ -23,15 +23,20 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
 import com.triviagenai.triviagen.R
+import com.triviagenai.triviagen.TriviaGameRoute
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
 import com.triviagenai.triviagen.ui.theme.RoyalPurple
 
 @Composable
-fun RoundSetupScreen() {
+fun RoundSetupScreen(navController: NavHostController) {
     var topicValue by remember { mutableStateOf("") }
 
-    TriviaGenScaffold(backNavigationIcon = true) {
+    TriviaGenScaffold(
+        backNavigationIcon = true,
+        navController = navController
+    ) {
         Column(
             modifier = Modifier
                 .fillMaxSize(),
@@ -45,20 +50,21 @@ fun RoundSetupScreen() {
                     .padding(bottom = dimensionResource(id = R.dimen.padding_small)),
                 value = topicValue,
                 onValueChange = { topicValue = it },
-                label = { Text("Label") },
+                label = { Text("Trivia Topic") },
                 colors = OutlinedTextFieldDefaults.colors(
                     focusedBorderColor = Color.White,
                     unfocusedBorderColor = Color.White,
                     focusedTextColor = Color.White,
                     unfocusedTextColor = Color.White,
                     unfocusedLabelColor = Color.White,
-                    focusedLabelColor = Color.White
+                    focusedLabelColor = Color.White,
+                    cursorColor = Color.White
                 ),
                 singleLine = true
             )
 
             ElevatedButton(
-                onClick = { /*TODO*/ },
+                onClick = { navController.navigate(TriviaGameRoute) },
                 shape = AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner)),
                 modifier = Modifier
                     .padding(dimensionResource(id = R.dimen.padding_small))
@@ -79,7 +85,7 @@ fun RoundSetupScreen() {
             )
 
             ElevatedButton(
-                onClick = { /*TODO*/ },
+                onClick = { navController.navigate(TriviaGameRoute) },
                 shape = AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner)),
                 modifier = Modifier
                     .padding(dimensionResource(id = R.dimen.padding_small))

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/roundsetup/RoundSetupScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/roundsetup/RoundSetupScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import com.triviagenai.triviagen.R
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
+import com.triviagenai.triviagen.core.presentation.navigation.NavigationStatus
 import com.triviagenai.triviagen.core.presentation.navigation.Route
 import com.triviagenai.triviagen.trivia.presentation.TriviaIntent
 import com.triviagenai.triviagen.trivia.presentation.TriviaQuestionViewModel
@@ -40,8 +41,7 @@ fun RoundSetupScreen(
     var topicValue by remember { mutableStateOf("") }
 
     TriviaGenScaffold(
-        backNavigationIcon = true,
-        navController = navController
+        navigationStatus = NavigationStatus.Enabled(navController)
     ) {
         Column(
             modifier = Modifier

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/roundsetup/RoundSetupScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/roundsetup/RoundSetupScreen.kt
@@ -57,7 +57,7 @@ fun RoundSetupScreen(
                     .padding(bottom = dimensionResource(id = R.dimen.padding_small)),
                 value = topicValue,
                 onValueChange = { topicValue = it },
-                label = { Text("Trivia Topic") },
+                label = { Text(stringResource(R.string.trivia_topic)) },
                 colors = OutlinedTextFieldDefaults.colors(
                     focusedBorderColor = Color.White,
                     unfocusedBorderColor = Color.White,

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/TriviaGameScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/TriviaGameScreen.kt
@@ -1,27 +1,47 @@
 package com.triviagenai.triviagen.trivia.presentation.triviagame
 
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.AbsoluteRoundedCornerShape
 import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
 import com.triviagenai.triviagen.R
+import com.triviagenai.triviagen.ResultsRoute
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
 import com.triviagenai.triviagen.trivia.domain.model.TriviaQuestion
+import com.triviagenai.triviagen.ui.theme.RoyalPurple
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 @Composable
-fun TriviaGameScreen() {
+fun TriviaGameScreen(navController: NavHostController) {
     val fakeData = listOf(
-        TriviaQuestion("What?", listOf("1", "2"), 0),
-        TriviaQuestion("What?", listOf("1", "2"), 0),
+        TriviaQuestion("What is the largest animal?", listOf("Option", "Correct answer", "Option", "Wrong answer"), 1),
+        TriviaQuestion("When was the prehistory?", listOf("1", "2", "Never", "Tomorrow"), 0),
     )
+
+    var answer by remember { mutableIntStateOf(-1) }
+    var questionIndex by remember { mutableIntStateOf(0) }
 
     TriviaGenScaffold {
         Column(
@@ -30,20 +50,42 @@ fun TriviaGameScreen() {
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Text(
-                text = fakeData[0].question,
+                text = fakeData[questionIndex].question,
+                fontSize = MaterialTheme.typography.titleMedium.fontSize,
                 modifier = Modifier
                     .padding(dimensionResource(id = R.dimen.padding_medium))
             )
 
-            fakeData[0].options.forEachIndexed { index, trivia ->
+            fakeData[questionIndex].options.forEachIndexed { index, trivia ->
                 Button(
                     onClick = {
-
+                        answer = index
+                        CoroutineScope(Dispatchers.Main).launch {
+                            if(questionIndex == fakeData.lastIndex) {
+                                delay(3000)
+                                navController.navigate(ResultsRoute)
+                            }
+                            delay(3000)
+                            questionIndex++
+                            answer = -1
+                        }
                     },
                     shape = AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner)),
                     modifier = Modifier
                         .padding(dimensionResource(id = R.dimen.padding_small))
                         .width(dimensionResource(id = R.dimen.element_xlarge))
+                        .border(
+                            if (answer > -1) 4.dp else (-1).dp,
+                            Brush.linearGradient(
+                                colors =
+                                    if (index == fakeData[0].answer) listOf(RoyalPurple, Color.Green)
+                                    else if (index == answer) listOf(RoyalPurple, Color.Red)
+                                    else listOf(RoyalPurple, RoyalPurple),
+                                start = Offset(0.0f, 0.0f),
+                                end = Offset(100.0f, 300.0f)
+                            ),
+                            AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner))
+                        )
                 ) {
                     Text(
                         text = trivia,

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/TriviaGameScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/TriviaGameScreen.kt
@@ -23,8 +23,7 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import com.triviagenai.triviagen.R
-import com.triviagenai.triviagen.ResultsRoute
-import com.triviagenai.triviagen.TriviaGameRoute
+import com.triviagenai.triviagen.core.presentation.Route
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
 import com.triviagenai.triviagen.trivia.domain.model.TriviaQuestion
 import com.triviagenai.triviagen.ui.theme.RoyalPurple
@@ -63,8 +62,8 @@ fun TriviaGameScreen(navController: NavHostController) {
                         CoroutineScope(Dispatchers.Main).launch {
                             if(questionIndex == fakeData.lastIndex) {
                                 delay(3000)
-                                navController.navigate(ResultsRoute) {
-                                    popUpTo(TriviaGameRoute) { inclusive = true }
+                                navController.navigate(Route.ResultsRoute) {
+                                    popUpTo(Route.TriviaGameRoute) { inclusive = true }
                                 }
                             }
                             delay(2000)

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/TriviaGameScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/TriviaGameScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import com.triviagenai.triviagen.R
@@ -45,7 +47,8 @@ fun TriviaGameScreen(navController: NavHostController) {
     TriviaGenScaffold {
         Column(
             modifier = Modifier
-                .fillMaxSize(),
+                .fillMaxSize()
+                .semantics { contentDescription = "TriviaGameScreen" },
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Text(

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/TriviaGameScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/TriviaGameScreen.kt
@@ -21,10 +21,10 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
 import com.triviagenai.triviagen.R
 import com.triviagenai.triviagen.ResultsRoute
+import com.triviagenai.triviagen.TriviaGameRoute
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
 import com.triviagenai.triviagen.trivia.domain.model.TriviaQuestion
 import com.triviagenai.triviagen.ui.theme.RoyalPurple
@@ -63,9 +63,11 @@ fun TriviaGameScreen(navController: NavHostController) {
                         CoroutineScope(Dispatchers.Main).launch {
                             if(questionIndex == fakeData.lastIndex) {
                                 delay(3000)
-                                navController.navigate(ResultsRoute)
+                                navController.navigate(ResultsRoute) {
+                                    popUpTo(TriviaGameRoute) { inclusive = true }
+                                }
                             }
-                            delay(3000)
+                            delay(2000)
                             questionIndex++
                             answer = -1
                         }

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/TriviaGameScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/TriviaGameScreen.kt
@@ -13,8 +13,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
+import com.triviagenai.triviagen.core.presentation.navigation.NavigationStatus
 import com.triviagenai.triviagen.trivia.presentation.TriviaQuestionViewModel
 import com.triviagenai.triviagen.trivia.presentation.TriviaUIState
+import com.triviagenai.triviagen.trivia.presentation.results.components.NavigationButtons
 import com.triviagenai.triviagen.trivia.presentation.triviagame.components.DisplayGameContent
 
 @Composable
@@ -24,7 +26,9 @@ fun TriviaGameScreen(
 ) {
     val triviaRound by triviaQuestionViewModel.uiState.collectAsState()
     var selectedIndex by remember { mutableIntStateOf(-1) }
-    TriviaGenScaffold {
+    TriviaGenScaffold(
+        navigationStatus = NavigationStatus.None
+    ) {
         when (triviaRound) {
             is TriviaUIState.Success -> DisplayGameContent(
                 triviaRound,

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/TriviaGameScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/TriviaGameScreen.kt
@@ -16,7 +16,6 @@ import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
 import com.triviagenai.triviagen.core.presentation.navigation.NavigationStatus
 import com.triviagenai.triviagen.trivia.presentation.TriviaQuestionViewModel
 import com.triviagenai.triviagen.trivia.presentation.TriviaUIState
-import com.triviagenai.triviagen.trivia.presentation.results.components.NavigationButtons
 import com.triviagenai.triviagen.trivia.presentation.triviagame.components.DisplayGameContent
 
 @Composable

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/components/DisplayGameContent.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/components/DisplayGameContent.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
@@ -20,6 +21,7 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import com.triviagenai.triviagen.R
+import com.triviagenai.triviagen.core.presentation.navigation.Route
 import com.triviagenai.triviagen.trivia.domain.model.SelectedAnswerState
 import com.triviagenai.triviagen.trivia.presentation.TriviaIntent
 import com.triviagenai.triviagen.trivia.presentation.TriviaQuestionViewModel
@@ -47,6 +49,18 @@ fun DisplayGameContent(
             wrongAnswerColor
         else
             optionColor
+    }
+
+    LaunchedEffect(triviaRound.questions.size, triviaRound.currentQuestionIndex, questionBlock.selectedAnswer) {
+        if (triviaRound.questions.isNotEmpty() &&
+            triviaRound.questions.size - 1 == triviaRound.currentQuestionIndex &&
+            questionBlock.selectedAnswer != SelectedAnswerState.Unanswered) {
+            navController.navigate(Route.ResultsRoute) {
+                popUpTo(Route.TriviaGameRoute) {
+                    inclusive = true
+                }
+            }
+        }
     }
 
     Column(

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/components/DisplayGameContent.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/components/DisplayGameContent.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.AbsoluteRoundedCornerShape
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -81,7 +83,12 @@ fun DisplayGameContent(
                             borderColors(LightGreen, LightRed, Color.Transparent, index),
                         spotColor =
                             borderColors(TriviaGreen, TriviaRed, Color.Gray, index)
-                    )
+                    ),
+                enabled = viewModel.isOptionButtonEnabled,
+                colors = ButtonDefaults.buttonColors(
+                    disabledContentColor = MaterialTheme.colorScheme.onBackground,
+                    disabledContainerColor = MaterialTheme.colorScheme.primary
+                )
             ) {
                 Text(
                     text = trivia, color = Color.White

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/components/DisplayGameContent.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/components/DisplayGameContent.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
@@ -49,7 +50,10 @@ fun DisplayGameContent(
     }
 
     Column(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag("TriviaGameScreen")
+        ,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(

--- a/app/src/main/java/com/triviagenai/triviagen/ui/theme/Type.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/ui/theme/Type.kt
@@ -35,6 +35,14 @@ val Typography = Typography(
         letterSpacing = 0.sp,
         color = Color.White
     ),
+    titleMedium = TextStyle(
+        fontFamily = karmaFontFamily,
+        fontWeight = FontWeight.W600,
+        fontSize = 24.sp,
+        lineHeight = 28.sp,
+        letterSpacing = 0.sp,
+        color = Color.White
+    ),
     labelSmall = TextStyle(
         fontFamily = karmaFontFamily,
         fontWeight = FontWeight.Medium,

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -8,7 +8,7 @@
     <dimen name="rounded_corner">8dp</dimen>
 
     <dimen name="element_small">34dp</dimen>
-    <dimen name="element_large">180dp</dimen>
+    <dimen name="element_large">200dp</dimen>
     <dimen name="element_xlarge">320dp</dimen>
 
     <dimen name="element_height">70dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,5 @@
     <string name="view_answers">View Answers</string>
     <string name="home">Home</string>
     <string name="retry">Retry</string>
+    <string name="trivia_topic">Trivia topic</string>
 </resources>


### PR DESCRIPTION
Added navigation in whole app. For the TriviaGameScreen I have created local states to handle the game behavior (I mean that question change), because creating view models was beyond my task. This also refers to quit button. The test doesn't allow to use LocalContext in the composable, so it must be done by creating a special function to quit app in the view model.
 
I don't know if it's shown well in the video, but once the user finishes the trivia, they can't go back.

https://github.com/sidcgithub/ai-trivia-app-android/assets/91783342/feb1e08d-2963-4397-94e4-c04d8bb99b90




One question for reviewer: can the navController parameter in TriviaGenScaffold.kt be optional?