### PR TITLE
TRIVIAGEN-21: connect viewmodel to screens

### DIFF
--- a/app/src/main/java/com/triviagenai/triviagen/MainActivity.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/MainActivity.kt
@@ -37,6 +37,7 @@ class MainActivity : ComponentActivity() {
                 Box(
                     Modifier
                         .fillMaxSize()
+                        // TODO: Replace with a proper navigation system
                         .clickable { if (++screenNumber > 3) screenNumber = 0 }) {
                     when (screenNumber) {
                         0 -> RoundSetupScreen(triviaQuestionViewModel)

--- a/app/src/main/java/com/triviagenai/triviagen/MainActivity.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/MainActivity.kt
@@ -5,7 +5,20 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.triviagenai.triviagen.trivia.presentation.TriviaQuestionViewModel
+import com.triviagenai.triviagen.trivia.presentation.answers.AnswersScreen
 import com.triviagenai.triviagen.trivia.presentation.results.ResultsScreen
+import com.triviagenai.triviagen.trivia.presentation.roundsetup.RoundSetupScreen
+import com.triviagenai.triviagen.trivia.presentation.triviagame.TriviaGameScreen
 import com.triviagenai.triviagen.ui.theme.TriviaGenTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -17,7 +30,21 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             TriviaGenTheme {
-                ResultsScreen()
+                val triviaQuestionViewModel: TriviaQuestionViewModel = hiltViewModel()
+                var screenNumber by remember {
+                    mutableIntStateOf(0)
+                }
+                Box(
+                    Modifier
+                        .fillMaxSize()
+                        .clickable { if (++screenNumber > 3) screenNumber = 0 }) {
+                    when (screenNumber) {
+                        0 -> RoundSetupScreen(triviaQuestionViewModel)
+                        1 -> TriviaGameScreen(triviaQuestionViewModel)
+                        2 -> ResultsScreen(triviaQuestionViewModel)
+                        3 -> AnswersScreen(triviaQuestionViewModel)
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/domain/model/TriviaQuestion.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/domain/model/TriviaQuestion.kt
@@ -5,7 +5,8 @@ import com.triviagenai.triviagen.trivia.data.model.Round
 data class TriviaQuestion(
     val question: String,
     val options: List<String>,
-    val answer: Int
+    val answer: Int,
+    val selectedAnswer: Int = -1,
 )
 
 fun Round.TriviaRound.mapToTriviaQuestions() = questions.map { question ->

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/domain/model/TriviaQuestion.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/domain/model/TriviaQuestion.kt
@@ -6,7 +6,7 @@ data class TriviaQuestion(
     val question: String,
     val options: List<String>,
     val answer: Int,
-    val selectedAnswer: Int = -1,
+    val selectedAnswer: SelectedAnswerState = SelectedAnswerState.Unanswered,
 )
 
 fun Round.TriviaRound.mapToTriviaQuestions() = questions.map { question ->
@@ -15,4 +15,9 @@ fun Round.TriviaRound.mapToTriviaQuestions() = questions.map { question ->
         question.options,
         question.answer
     )
+}
+
+sealed class SelectedAnswerState {
+    object Unanswered : SelectedAnswerState()
+    data class Answered(val answer: Int) : SelectedAnswerState()
 }

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/TriviaQuestionViewModel.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/TriviaQuestionViewModel.kt
@@ -50,6 +50,10 @@ class TriviaQuestionViewModel @Inject constructor(
     fun fetchTriviaQuestions(topic: String) {
         viewModelScope.launch {
             _uiState.value = TriviaUIState.Loading
+            if (topic.isEmpty()) {
+                _uiState.value = TriviaUIState.Error("Topic is empty")
+                return@launch
+            }
             getTriviaQuestionsUseCase(topic).collect { result ->
                 result?.onSuccess { questions ->
                     _uiState.value = TriviaUIState.Success(questions.toMutableList(), 0, 0)

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/TriviaQuestionViewModel.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/TriviaQuestionViewModel.kt
@@ -2,6 +2,7 @@ package com.triviagenai.triviagen.trivia.presentation
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.triviagenai.triviagen.trivia.domain.model.SelectedAnswerState
 import com.triviagenai.triviagen.trivia.domain.usecase.GetTriviaQuestionsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
@@ -59,14 +60,14 @@ class TriviaQuestionViewModel @Inject constructor(
         }
     }
 
-    fun fetchRandomTriviaRoundQuestions() {
+    private fun fetchRandomTriviaRoundQuestions() {
         fetchTriviaQuestions(categories.random())
     }
 
     fun processIntent(intent: TriviaIntent) {
         when (intent) {
             is TriviaIntent.SubmitAnswer -> viewModelScope.launch { submitAnswer(intent.selectedOptionIndex) }
-            TriviaIntent.NextQuestion -> nextQuestion()
+            TriviaIntent.RandomTriviaRound -> fetchRandomTriviaRoundQuestions()
         }
     }
 
@@ -85,7 +86,11 @@ class TriviaQuestionViewModel @Inject constructor(
         if (currentState is TriviaUIState.Success) {
             val currentQuestion = currentState.questions[currentState.currentQuestionIndex]
             currentState.questions[currentState.currentQuestionIndex] =
-                currentQuestion.copy(selectedAnswer = selectedOptionIndex)
+                currentQuestion.copy(
+                    selectedAnswer = SelectedAnswerState.Answered(
+                        selectedOptionIndex
+                    )
+                )
             if (selectedOptionIndex == currentQuestion.answer) {
                 _uiState.value =
                     currentState.copy(score = currentState.score + POINTS)
@@ -98,5 +103,5 @@ class TriviaQuestionViewModel @Inject constructor(
 
 sealed class TriviaIntent {
     data class SubmitAnswer(val selectedOptionIndex: Int) : TriviaIntent()
-    object NextQuestion : TriviaIntent()
+    object RandomTriviaRound : TriviaIntent()
 }

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/TriviaUIState.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/TriviaUIState.kt
@@ -5,9 +5,9 @@ import com.triviagenai.triviagen.trivia.domain.model.TriviaQuestion
 sealed class TriviaUIState {
     object Loading : TriviaUIState()
     data class Success(
-        val questions: List<TriviaQuestion>,
+        val questions: MutableList<TriviaQuestion>,
         val currentQuestionIndex: Int,
-        val score: Int
+        val score: Int,
     ) : TriviaUIState()
 
     data class Error(val message: String) : TriviaUIState()

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/answers/AnswersScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/answers/AnswersScreen.kt
@@ -2,6 +2,7 @@ package com.triviagenai.triviagen.trivia.presentation.answers
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
@@ -27,8 +28,14 @@ fun AnswersScreen(triviaQuestionViewModel: TriviaQuestionViewModel) {
             modifier = Modifier
                 .fillMaxSize()
         ) {
-            items(trivia.size) { index ->
-                TriviaAnswerCard(trivia[index])
+            if(trivia.isEmpty()) {
+                item {
+                    Text(text = "Sorry, we couldn't display your answers")
+                }
+            } else {
+                items(trivia.size) { index ->
+                    TriviaAnswerCard(trivia[index])
+                }
             }
         }
     }

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/answers/AnswersScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/answers/AnswersScreen.kt
@@ -3,18 +3,23 @@ package com.triviagenai.triviagen.trivia.presentation.answers
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
-import com.triviagenai.triviagen.trivia.domain.model.TriviaQuestion
+import com.triviagenai.triviagen.trivia.presentation.TriviaQuestionViewModel
+import com.triviagenai.triviagen.trivia.presentation.TriviaUIState
 import com.triviagenai.triviagen.trivia.presentation.answers.components.TriviaAnswerCard
 
 @Composable
-fun AnswersScreen() {
-    val trivias = listOf(
-        TriviaQuestion("What?", listOf("1", "2"), 0),
-        TriviaQuestion("What?", listOf("1", "2"), 0),
-    )
+fun AnswersScreen(triviaQuestionViewModel: TriviaQuestionViewModel) {
+    val trivia = triviaQuestionViewModel.uiState.collectAsState().value.let {
+        if (it is TriviaUIState.Success) {
+            it.questions
+        } else {
+            emptyList()
+        }
+    }
 
     TriviaGenScaffold(backNavigationIcon = true) {
         LazyColumn(
@@ -22,8 +27,8 @@ fun AnswersScreen() {
             modifier = Modifier
                 .fillMaxSize()
         ) {
-            items(trivias.size) { index ->
-                TriviaAnswerCard(trivias[index])
+            items(trivia.size) { index ->
+                TriviaAnswerCard(trivia[index])
             }
         }
     }

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/answers/components/TriviaAnswerCard.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/answers/components/TriviaAnswerCard.kt
@@ -48,11 +48,11 @@ fun TriviaAnswerCard(triviaQuestion: TriviaQuestion) {
                     .padding(dimensionResource(id = R.dimen.padding_medium))
             )
 
-            val checkedOption = 1 //TODO replace with state with real user answer. This value is for testing only.
+            val checkedOption = triviaQuestion.selectedAnswer
 
-            for (i in 0..3) {
+            triviaQuestion.options.forEachIndexed { i, option ->
                 Text(
-                    text = triviaQuestion.options[i],
+                    text = option,
                     modifier = Modifier
                         .padding(horizontal = dimensionResource(id = R.dimen.padding_medium))
                         .background(
@@ -60,7 +60,7 @@ fun TriviaAnswerCard(triviaQuestion: TriviaQuestion) {
                             AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner))
                         )
                         .border(
-                            width = 1.dp,
+                            width = dimensionResource(id = R.dimen.border_width),
                             color = if (i == triviaQuestion.answer) Color.Green else if (checkedOption == i) Color.Red else Color.Transparent,
                             shape = AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner))
                         )

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/answers/components/TriviaAnswerCard.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/answers/components/TriviaAnswerCard.kt
@@ -24,6 +24,8 @@ import com.triviagenai.triviagen.R
 import com.triviagenai.triviagen.trivia.domain.model.SelectedAnswerState
 import com.triviagenai.triviagen.trivia.domain.model.TriviaQuestion
 import com.triviagenai.triviagen.ui.theme.RoyalPurple
+import com.triviagenai.triviagen.ui.theme.TriviaGreen
+import com.triviagenai.triviagen.ui.theme.TriviaRed
 
 @Composable
 fun TriviaAnswerCard(triviaQuestion: TriviaQuestion) {
@@ -62,9 +64,9 @@ fun TriviaAnswerCard(triviaQuestion: TriviaQuestion) {
                             )
                             .border(
                                 width = dimensionResource(id = R.dimen.border_width),
-                                color = if (i == triviaQuestion.answer) Color.Green
+                                color = if (i == triviaQuestion.answer) TriviaGreen
                                 else {
-                                    if (selectedOption == i) Color.Red
+                                    if (selectedOption == i) TriviaRed
                                     else Color.Transparent
                                 },
                                 shape = AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner))

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/answers/components/TriviaAnswerCard.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/answers/components/TriviaAnswerCard.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.triviagenai.triviagen.R
+import com.triviagenai.triviagen.trivia.domain.model.SelectedAnswerState
 import com.triviagenai.triviagen.trivia.domain.model.TriviaQuestion
 import com.triviagenai.triviagen.ui.theme.RoyalPurple
 
@@ -47,30 +48,36 @@ fun TriviaAnswerCard(triviaQuestion: TriviaQuestion) {
                 modifier = Modifier
                     .padding(dimensionResource(id = R.dimen.padding_medium))
             )
-
-            val checkedOption = triviaQuestion.selectedAnswer
-
-            triviaQuestion.options.forEachIndexed { i, option ->
-                Text(
-                    text = option,
-                    modifier = Modifier
-                        .padding(horizontal = dimensionResource(id = R.dimen.padding_medium))
-                        .background(
-                            RoyalPurple,
-                            AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner))
-                        )
-                        .border(
-                            width = dimensionResource(id = R.dimen.border_width),
-                            color = if (i == triviaQuestion.answer) Color.Green else if (checkedOption == i) Color.Red else Color.Transparent,
-                            shape = AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner))
-                        )
-                        .height(dimensionResource(id = R.dimen.element_small))
-                        .fillMaxWidth()
-                        .padding(top = 5.dp),
-                    textAlign = TextAlign.Center
-                )
-                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.padding_small)))
+            if (triviaQuestion.selectedAnswer != SelectedAnswerState.Unanswered) {
+                val selectedOption =
+                    (triviaQuestion.selectedAnswer as SelectedAnswerState.Answered).answer
+                triviaQuestion.options.forEachIndexed { i, option ->
+                    Text(
+                        text = option,
+                        modifier = Modifier
+                            .padding(horizontal = dimensionResource(id = R.dimen.padding_medium))
+                            .background(
+                                RoyalPurple,
+                                AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner))
+                            )
+                            .border(
+                                width = dimensionResource(id = R.dimen.border_width),
+                                color = if (i == triviaQuestion.answer) Color.Green
+                                else {
+                                    if (selectedOption == i) Color.Red
+                                    else Color.Transparent
+                                },
+                                shape = AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner))
+                            )
+                            .height(dimensionResource(id = R.dimen.element_small))
+                            .fillMaxWidth()
+                            .padding(top = 5.dp),
+                        textAlign = TextAlign.Center
+                    )
+                    Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.padding_small)))
+                }
             }
+
 
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.padding_small)))
         }

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/results/ResultsScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/results/ResultsScreen.kt
@@ -16,6 +16,10 @@ import androidx.compose.material3.ElevatedButton
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -26,11 +30,24 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.triviagenai.triviagen.R
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
+import com.triviagenai.triviagen.trivia.presentation.TriviaQuestionViewModel
+import com.triviagenai.triviagen.trivia.presentation.TriviaUIState
 import com.triviagenai.triviagen.ui.theme.RoyalPurple
 
 @Composable
-fun ResultsScreen() {
-    val score = 0.51f
+fun ResultsScreen(triviaQuestionViewModel: TriviaQuestionViewModel) {
+    val state = triviaQuestionViewModel.uiState.collectAsState()
+    val score: Float by remember {
+        when (state.value) {
+            is TriviaUIState.Success -> {
+                mutableFloatStateOf((state.value as TriviaUIState.Success).score.toFloat())
+            }
+
+            else -> {
+                mutableFloatStateOf(0f)
+            }
+        }
+    }
 
     TriviaGenScaffold {
         Column(
@@ -43,7 +60,7 @@ fun ResultsScreen() {
                 contentAlignment = Alignment.Center
             ) {
                 CircularProgressIndicator(
-                    progress = score,
+                    progress = score / 25,
                     color = if (score > 0.5f) Color.Green else Color.Red,
                     strokeWidth = dimensionResource(id = R.dimen.element_small),
                     modifier = Modifier.size(dimensionResource(id = R.dimen.element_large)),
@@ -51,7 +68,7 @@ fun ResultsScreen() {
                 )
 
                 Text(
-                    text = "Score: ${(score * 100).toInt()}"
+                    text = "Score: ${(score).toInt()}"
                 )
             }
             Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.spacer_medium)))
@@ -63,7 +80,11 @@ fun ResultsScreen() {
                     .padding(dimensionResource(id = R.dimen.padding_small))
                     .width(dimensionResource(id = R.dimen.element_xlarge))
                     .height(dimensionResource(id = R.dimen.element_height))
-                    .border(1.dp, color = Color.White, shape = AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner)))
+                    .border(
+                        1.dp,
+                        color = Color.White,
+                        shape = AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner))
+                    )
             ) {
                 Text(
                     text = stringResource(R.string.view_answers),

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/results/ResultsScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/results/ResultsScreen.kt
@@ -35,6 +35,8 @@ import com.triviagenai.triviagen.trivia.presentation.TriviaQuestionViewModel
 import com.triviagenai.triviagen.trivia.presentation.TriviaQuestionViewModel.Companion.POINTS
 import com.triviagenai.triviagen.trivia.presentation.TriviaUIState
 import com.triviagenai.triviagen.ui.theme.RoyalPurple
+import com.triviagenai.triviagen.ui.theme.TriviaGreen
+import com.triviagenai.triviagen.ui.theme.TriviaRed
 
 @Composable
 fun ResultsScreen(triviaQuestionViewModel: TriviaQuestionViewModel) {
@@ -74,7 +76,7 @@ fun ResultsScreen(triviaQuestionViewModel: TriviaQuestionViewModel) {
             ) {
                 CircularProgressIndicator(
                     progress = score / (POINTS * questionsSize),
-                    color = if (score > 0.5f) Color.Green else Color.Red,
+                    color = if (score > 0.5f) TriviaGreen else TriviaRed,
                     strokeWidth = dimensionResource(id = R.dimen.element_small),
                     modifier = Modifier.size(dimensionResource(id = R.dimen.element_large)),
                     strokeCap = StrokeCap.Round

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/results/ResultsScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/results/ResultsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -31,6 +32,7 @@ import androidx.compose.ui.unit.dp
 import com.triviagenai.triviagen.R
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
 import com.triviagenai.triviagen.trivia.presentation.TriviaQuestionViewModel
+import com.triviagenai.triviagen.trivia.presentation.TriviaQuestionViewModel.Companion.POINTS
 import com.triviagenai.triviagen.trivia.presentation.TriviaUIState
 import com.triviagenai.triviagen.ui.theme.RoyalPurple
 
@@ -48,6 +50,17 @@ fun ResultsScreen(triviaQuestionViewModel: TriviaQuestionViewModel) {
             }
         }
     }
+    val questionsSize: Int by remember {
+        when (state.value) {
+            is TriviaUIState.Success -> {
+                mutableIntStateOf((state.value as TriviaUIState.Success).questions.size)
+            }
+
+            else -> {
+                mutableIntStateOf(0)
+            }
+        }
+    }
 
     TriviaGenScaffold {
         Column(
@@ -60,7 +73,7 @@ fun ResultsScreen(triviaQuestionViewModel: TriviaQuestionViewModel) {
                 contentAlignment = Alignment.Center
             ) {
                 CircularProgressIndicator(
-                    progress = score / 25,
+                    progress = score / (POINTS * questionsSize),
                     color = if (score > 0.5f) Color.Green else Color.Red,
                     strokeWidth = dimensionResource(id = R.dimen.element_small),
                     modifier = Modifier.size(dimensionResource(id = R.dimen.element_large)),

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/roundsetup/RoundSetupScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/roundsetup/RoundSetupScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -27,11 +28,13 @@ import com.triviagenai.triviagen.R
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
 import com.triviagenai.triviagen.trivia.presentation.TriviaIntent
 import com.triviagenai.triviagen.trivia.presentation.TriviaQuestionViewModel
+import com.triviagenai.triviagen.trivia.presentation.TriviaUIState
 import com.triviagenai.triviagen.ui.theme.RoyalPurple
 
 @Composable
 fun RoundSetupScreen(triviaQuestionViewModel: TriviaQuestionViewModel) {
     var topicValue by remember { mutableStateOf("") }
+    val uiState by triviaQuestionViewModel.uiState.collectAsState()
 
     TriviaGenScaffold(backNavigationIcon = true) {
         Column(
@@ -60,7 +63,9 @@ fun RoundSetupScreen(triviaQuestionViewModel: TriviaQuestionViewModel) {
             )
 
             ElevatedButton(
-                onClick = { triviaQuestionViewModel.fetchTriviaQuestions(topicValue) },
+                onClick = {
+                    triviaQuestionViewModel.fetchTriviaQuestions(topicValue)
+                },
                 shape = AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner)),
                 modifier = Modifier
                     .padding(dimensionResource(id = R.dimen.padding_small))

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/roundsetup/RoundSetupScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/roundsetup/RoundSetupScreen.kt
@@ -25,10 +25,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.triviagenai.triviagen.R
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
+import com.triviagenai.triviagen.trivia.presentation.TriviaQuestionViewModel
 import com.triviagenai.triviagen.ui.theme.RoyalPurple
 
 @Composable
-fun RoundSetupScreen() {
+fun RoundSetupScreen(triviaQuestionViewModel: TriviaQuestionViewModel) {
     var topicValue by remember { mutableStateOf("") }
 
     TriviaGenScaffold(backNavigationIcon = true) {
@@ -58,7 +59,7 @@ fun RoundSetupScreen() {
             )
 
             ElevatedButton(
-                onClick = { /*TODO*/ },
+                onClick = { triviaQuestionViewModel.fetchTriviaQuestions(topicValue) },
                 shape = AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner)),
                 modifier = Modifier
                     .padding(dimensionResource(id = R.dimen.padding_small))
@@ -79,7 +80,7 @@ fun RoundSetupScreen() {
             )
 
             ElevatedButton(
-                onClick = { /*TODO*/ },
+                onClick = { triviaQuestionViewModel.fetchRandomTriviaRoundQuestions() },
                 shape = AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner)),
                 modifier = Modifier
                     .padding(dimensionResource(id = R.dimen.padding_small))

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/roundsetup/RoundSetupScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/roundsetup/RoundSetupScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.triviagenai.triviagen.R
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
+import com.triviagenai.triviagen.trivia.presentation.TriviaIntent
 import com.triviagenai.triviagen.trivia.presentation.TriviaQuestionViewModel
 import com.triviagenai.triviagen.ui.theme.RoyalPurple
 
@@ -80,7 +81,7 @@ fun RoundSetupScreen(triviaQuestionViewModel: TriviaQuestionViewModel) {
             )
 
             ElevatedButton(
-                onClick = { triviaQuestionViewModel.fetchRandomTriviaRoundQuestions() },
+                onClick = { triviaQuestionViewModel.processIntent(TriviaIntent.RandomTriviaRound) },
                 shape = AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner)),
                 modifier = Modifier
                     .padding(dimensionResource(id = R.dimen.padding_small))

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/TriviaGameScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/TriviaGameScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.dimensionResource
 import com.triviagenai.triviagen.R
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
+import com.triviagenai.triviagen.trivia.domain.model.SelectedAnswerState
 import com.triviagenai.triviagen.trivia.presentation.TriviaIntent
 import com.triviagenai.triviagen.trivia.presentation.TriviaQuestionViewModel
 import com.triviagenai.triviagen.trivia.presentation.TriviaUIState
@@ -51,12 +52,15 @@ fun TriviaGameScreen(triviaQuestionViewModel: TriviaQuestionViewModel) {
                     questionBlock.options.forEachIndexed { index, trivia ->
                         Button(
                             onClick = {
-                                selectedIndex = index
-                                triviaQuestionViewModel.processIntent(
-                                    TriviaIntent.SubmitAnswer(
-                                        index
+                                if (questionBlock.selectedAnswer is SelectedAnswerState.Unanswered) {
+                                    selectedIndex = index
+
+                                    triviaQuestionViewModel.processIntent(
+                                        TriviaIntent.SubmitAnswer(
+                                            index
+                                        )
                                     )
-                                )
+                                }
                             },
                             shape = AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner)),
                             modifier = Modifier
@@ -64,7 +68,7 @@ fun TriviaGameScreen(triviaQuestionViewModel: TriviaQuestionViewModel) {
                                 .width(dimensionResource(id = R.dimen.element_xlarge))
                                 .border(
                                     dimensionResource(id = R.dimen.border_width),
-                                    if (selectedIndex == index && questionBlock.selectedAnswer != -1) {
+                                    if (selectedIndex == index && questionBlock.selectedAnswer !is SelectedAnswerState.Unanswered) {
                                         if (selectedIndex == questionBlock.answer) Color.Green else Color.Red
                                     } else {
                                         Color.Gray
@@ -73,12 +77,12 @@ fun TriviaGameScreen(triviaQuestionViewModel: TriviaQuestionViewModel) {
                                 )
                                 .shadow(
                                     elevation = dimensionResource(id = R.dimen.elevation_small),
-                                    ambientColor = if (selectedIndex == index && questionBlock.selectedAnswer != -1) {
+                                    ambientColor = if (selectedIndex == index && questionBlock.selectedAnswer !is SelectedAnswerState.Unanswered) {
                                         if (selectedIndex == questionBlock.answer) LightGreen else LightRed
                                     } else {
                                         Color.Transparent
                                     },
-                                    spotColor = if (selectedIndex == index && questionBlock.selectedAnswer != -1) {
+                                    spotColor = if (selectedIndex == index && questionBlock.selectedAnswer !is SelectedAnswerState.Unanswered) {
                                         if (selectedIndex == questionBlock.answer) LightGreen else LightRed
                                     } else {
                                         Color.Gray

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/TriviaGameScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/TriviaGameScreen.kt
@@ -1,5 +1,7 @@
 package com.triviagenai.triviagen.trivia.presentation.triviagame
 
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -8,48 +10,101 @@ import androidx.compose.foundation.shape.AbsoluteRoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.dimensionResource
 import com.triviagenai.triviagen.R
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
-import com.triviagenai.triviagen.trivia.domain.model.TriviaQuestion
+import com.triviagenai.triviagen.trivia.presentation.TriviaIntent
+import com.triviagenai.triviagen.trivia.presentation.TriviaQuestionViewModel
+import com.triviagenai.triviagen.trivia.presentation.TriviaUIState
+import com.triviagenai.triviagen.ui.theme.LightGreen
+import com.triviagenai.triviagen.ui.theme.LightRed
 
 @Composable
-fun TriviaGameScreen() {
-    val fakeData = listOf(
-        TriviaQuestion("What?", listOf("1", "2"), 0),
-        TriviaQuestion("What?", listOf("1", "2"), 0),
-    )
-
+fun TriviaGameScreen(triviaQuestionViewModel: TriviaQuestionViewModel) {
+    val triviaRound by triviaQuestionViewModel.uiState.collectAsState()
+    var selectedIndex by remember { mutableIntStateOf(-1) }
     TriviaGenScaffold {
-        Column(
-            modifier = Modifier
-                .fillMaxSize(),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Text(
-                text = fakeData[0].question,
-                modifier = Modifier
-                    .padding(dimensionResource(id = R.dimen.padding_medium))
-            )
-
-            fakeData[0].options.forEachIndexed { index, trivia ->
-                Button(
-                    onClick = {
-
-                    },
-                    shape = AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner)),
+        when (triviaRound) {
+            is TriviaUIState.Success ->
+                Column(
                     modifier = Modifier
-                        .padding(dimensionResource(id = R.dimen.padding_small))
-                        .width(dimensionResource(id = R.dimen.element_xlarge))
+                        .fillMaxSize(),
+                    horizontalAlignment = Alignment.CenterHorizontally
                 ) {
+                    val questionBlock =
+                        (triviaRound as TriviaUIState.Success).questions[(triviaRound as TriviaUIState.Success).currentQuestionIndex]
                     Text(
-                        text = trivia,
-                        color = Color.White
+                        text = questionBlock.question,
+                        modifier = Modifier
+                            .padding(dimensionResource(id = R.dimen.padding_medium))
                     )
+
+                    questionBlock.options.forEachIndexed { index, trivia ->
+                        Button(
+                            onClick = {
+                                selectedIndex = index
+                                triviaQuestionViewModel.processIntent(
+                                    TriviaIntent.SubmitAnswer(
+                                        index
+                                    )
+                                )
+                            },
+                            shape = AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner)),
+                            modifier = Modifier
+                                .padding(dimensionResource(id = R.dimen.padding_small))
+                                .width(dimensionResource(id = R.dimen.element_xlarge))
+                                .border(
+                                    dimensionResource(id = R.dimen.border_width),
+                                    if (selectedIndex == index && questionBlock.selectedAnswer != -1) {
+                                        if (selectedIndex == questionBlock.answer) Color.Green else Color.Red
+                                    } else {
+                                        Color.Gray
+                                    },
+                                    AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner))
+                                )
+                                .shadow(
+                                    elevation = dimensionResource(id = R.dimen.elevation_small),
+                                    ambientColor = if (selectedIndex == index && questionBlock.selectedAnswer != -1) {
+                                        if (selectedIndex == questionBlock.answer) LightGreen else LightRed
+                                    } else {
+                                        Color.Transparent
+                                    },
+                                    spotColor = if (selectedIndex == index && questionBlock.selectedAnswer != -1) {
+                                        if (selectedIndex == questionBlock.answer) LightGreen else LightRed
+                                    } else {
+                                        Color.Gray
+                                    }
+                                )
+                        ) {
+                            Text(
+                                text = trivia,
+                                color = Color.White
+                            )
+                        }
+                    }
                 }
+
+            is TriviaUIState.Error -> Box(modifier = Modifier.fillMaxSize()) {
+                Text(
+                    text = (triviaRound as TriviaUIState.Error).message,
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
+
+            TriviaUIState.Loading -> Box(modifier = Modifier.fillMaxSize()) {
+                Text(
+                    text = "Loading...",
+                    modifier = Modifier.align(Alignment.Center)
+                )
             }
         }
     }

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/TriviaGameScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/TriviaGameScreen.kt
@@ -22,11 +22,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.dimensionResource
 import com.triviagenai.triviagen.R
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
+import com.triviagenai.triviagen.trivia.domain.model.SelectedAnswerState
 import com.triviagenai.triviagen.trivia.presentation.TriviaIntent
 import com.triviagenai.triviagen.trivia.presentation.TriviaQuestionViewModel
 import com.triviagenai.triviagen.trivia.presentation.TriviaUIState
 import com.triviagenai.triviagen.ui.theme.LightGreen
 import com.triviagenai.triviagen.ui.theme.LightRed
+import com.triviagenai.triviagen.ui.theme.TriviaGreen
+import com.triviagenai.triviagen.ui.theme.TriviaRed
 
 @Composable
 fun TriviaGameScreen(triviaQuestionViewModel: TriviaQuestionViewModel) {
@@ -37,6 +40,7 @@ fun TriviaGameScreen(triviaQuestionViewModel: TriviaQuestionViewModel) {
             is TriviaUIState.Success -> DisplayGameContent(
                 triviaRound,
                 selectedIndex,
+                { index -> selectedIndex = index },
                 triviaQuestionViewModel
             )
 
@@ -61,36 +65,39 @@ fun TriviaGameScreen(triviaQuestionViewModel: TriviaQuestionViewModel) {
 private fun DisplayGameContent(
     triviaRound: TriviaUIState,
     selectedIndex: Int,
-    triviaQuestionViewModel: TriviaQuestionViewModel
+    setSelectedIndex: (Int) -> Unit,
+    viewModel: TriviaQuestionViewModel
 ) {
-    var updatedIndex = selectedIndex
-
     Column(
         modifier = Modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        val questionBlock = (triviaRound as TriviaUIState.Success).questions[(triviaRound as TriviaUIState.Success).currentQuestionIndex]
+        val questionBlock =
+            (triviaRound as TriviaUIState.Success).questions[(triviaRound).currentQuestionIndex]
 
         Text(
-            text = questionBlock.question, modifier = Modifier.padding(dimensionResource(id = R.dimen.padding_medium))
+            text = questionBlock.question,
+            modifier = Modifier.padding(dimensionResource(id = R.dimen.padding_medium))
         )
 
         questionBlock.options.forEachIndexed { index, trivia ->
             Button(
                 onClick = {
-                    updatedIndex = index
-                    triviaQuestionViewModel.processIntent(
+                    setSelectedIndex(index)
+                    viewModel.processIntent(
                         TriviaIntent.SubmitAnswer(
                             index
                         )
                     )
                 },
                 shape = AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner)),
-                modifier = Modifier.padding(dimensionResource(id = R.dimen.padding_small)).width(dimensionResource(id = R.dimen.element_xlarge))
+                modifier = Modifier
+                    .padding(dimensionResource(id = R.dimen.padding_small))
+                    .width(dimensionResource(id = R.dimen.element_xlarge))
                     .border(
                         dimensionResource(id = R.dimen.border_width),
-                        if (updatedIndex == index && questionBlock.selectedAnswer != -1) {
-                            if (updatedIndex == questionBlock.answer) Color.Green else Color.Red
+                        if (selectedIndex == index && questionBlock.selectedAnswer != SelectedAnswerState.Unanswered) {
+                            if (selectedIndex == questionBlock.answer) TriviaGreen else TriviaRed
                         } else {
                             Color.Gray
                         },
@@ -99,17 +106,17 @@ private fun DisplayGameContent(
                     .shadow(
                         elevation = dimensionResource(id = R.dimen.elevation_small),
                         ambientColor =
-                            if (updatedIndex == index && questionBlock.selectedAnswer != -1) {
-                                if (updatedIndex == questionBlock.answer) LightGreen else LightRed
-                            } else {
-                                Color.Transparent
-                            },
+                        if (selectedIndex == index && questionBlock.selectedAnswer != SelectedAnswerState.Unanswered) {
+                            if (selectedIndex == questionBlock.answer) LightGreen else LightRed
+                        } else {
+                            Color.Transparent
+                        },
                         spotColor =
-                            if (updatedIndex == index && questionBlock.selectedAnswer != -1) {
-                                if (updatedIndex == questionBlock.answer) LightGreen else LightRed
-                            } else {
-                                Color.Gray
-                            }
+                        if (selectedIndex == index && questionBlock.selectedAnswer != SelectedAnswerState.Unanswered) {
+                            if (selectedIndex == questionBlock.answer) LightGreen else LightRed
+                        } else {
+                            Color.Gray
+                        }
                     )
             ) {
                 Text(

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/TriviaGameScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/TriviaGameScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.dimensionResource
 import com.triviagenai.triviagen.R
 import com.triviagenai.triviagen.core.presentation.TriviaGenScaffold
-import com.triviagenai.triviagen.trivia.domain.model.SelectedAnswerState
 import com.triviagenai.triviagen.trivia.presentation.TriviaIntent
 import com.triviagenai.triviagen.trivia.presentation.TriviaQuestionViewModel
 import com.triviagenai.triviagen.trivia.presentation.TriviaUIState
@@ -35,67 +34,11 @@ fun TriviaGameScreen(triviaQuestionViewModel: TriviaQuestionViewModel) {
     var selectedIndex by remember { mutableIntStateOf(-1) }
     TriviaGenScaffold {
         when (triviaRound) {
-            is TriviaUIState.Success ->
-                Column(
-                    modifier = Modifier
-                        .fillMaxSize(),
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    val questionBlock =
-                        (triviaRound as TriviaUIState.Success).questions[(triviaRound as TriviaUIState.Success).currentQuestionIndex]
-                    Text(
-                        text = questionBlock.question,
-                        modifier = Modifier
-                            .padding(dimensionResource(id = R.dimen.padding_medium))
-                    )
-
-                    questionBlock.options.forEachIndexed { index, trivia ->
-                        Button(
-                            onClick = {
-                                if (questionBlock.selectedAnswer is SelectedAnswerState.Unanswered) {
-                                    selectedIndex = index
-
-                                    triviaQuestionViewModel.processIntent(
-                                        TriviaIntent.SubmitAnswer(
-                                            index
-                                        )
-                                    )
-                                }
-                            },
-                            shape = AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner)),
-                            modifier = Modifier
-                                .padding(dimensionResource(id = R.dimen.padding_small))
-                                .width(dimensionResource(id = R.dimen.element_xlarge))
-                                .border(
-                                    dimensionResource(id = R.dimen.border_width),
-                                    if (selectedIndex == index && questionBlock.selectedAnswer !is SelectedAnswerState.Unanswered) {
-                                        if (selectedIndex == questionBlock.answer) Color.Green else Color.Red
-                                    } else {
-                                        Color.Gray
-                                    },
-                                    AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner))
-                                )
-                                .shadow(
-                                    elevation = dimensionResource(id = R.dimen.elevation_small),
-                                    ambientColor = if (selectedIndex == index && questionBlock.selectedAnswer !is SelectedAnswerState.Unanswered) {
-                                        if (selectedIndex == questionBlock.answer) LightGreen else LightRed
-                                    } else {
-                                        Color.Transparent
-                                    },
-                                    spotColor = if (selectedIndex == index && questionBlock.selectedAnswer !is SelectedAnswerState.Unanswered) {
-                                        if (selectedIndex == questionBlock.answer) LightGreen else LightRed
-                                    } else {
-                                        Color.Gray
-                                    }
-                                )
-                        ) {
-                            Text(
-                                text = trivia,
-                                color = Color.White
-                            )
-                        }
-                    }
-                }
+            is TriviaUIState.Success -> DisplayGameContent(
+                triviaRound,
+                selectedIndex,
+                triviaQuestionViewModel
+            )
 
             is TriviaUIState.Error -> Box(modifier = Modifier.fillMaxSize()) {
                 Text(
@@ -108,6 +51,69 @@ fun TriviaGameScreen(triviaQuestionViewModel: TriviaQuestionViewModel) {
                 Text(
                     text = "Loading...",
                     modifier = Modifier.align(Alignment.Center)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DisplayGameContent(
+    triviaRound: TriviaUIState,
+    selectedIndex: Int,
+    triviaQuestionViewModel: TriviaQuestionViewModel
+) {
+    var updatedIndex = selectedIndex
+
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        val questionBlock = (triviaRound as TriviaUIState.Success).questions[(triviaRound as TriviaUIState.Success).currentQuestionIndex]
+
+        Text(
+            text = questionBlock.question, modifier = Modifier.padding(dimensionResource(id = R.dimen.padding_medium))
+        )
+
+        questionBlock.options.forEachIndexed { index, trivia ->
+            Button(
+                onClick = {
+                    updatedIndex = index
+                    triviaQuestionViewModel.processIntent(
+                        TriviaIntent.SubmitAnswer(
+                            index
+                        )
+                    )
+                },
+                shape = AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner)),
+                modifier = Modifier.padding(dimensionResource(id = R.dimen.padding_small)).width(dimensionResource(id = R.dimen.element_xlarge))
+                    .border(
+                        dimensionResource(id = R.dimen.border_width),
+                        if (updatedIndex == index && questionBlock.selectedAnswer != -1) {
+                            if (updatedIndex == questionBlock.answer) Color.Green else Color.Red
+                        } else {
+                            Color.Gray
+                        },
+                        AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner))
+                    )
+                    .shadow(
+                        elevation = dimensionResource(id = R.dimen.elevation_small),
+                        ambientColor =
+                            if (updatedIndex == index && questionBlock.selectedAnswer != -1) {
+                                if (updatedIndex == questionBlock.answer) LightGreen else LightRed
+                            } else {
+                                Color.Transparent
+                            },
+                        spotColor =
+                            if (updatedIndex == index && questionBlock.selectedAnswer != -1) {
+                                if (updatedIndex == questionBlock.answer) LightGreen else LightRed
+                            } else {
+                                Color.Gray
+                            }
+                    )
+            ) {
+                Text(
+                    text = trivia, color = Color.White
                 )
             }
         }

--- a/app/src/main/java/com/triviagenai/triviagen/ui/theme/Color.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/ui/theme/Color.kt
@@ -15,3 +15,5 @@ val DarkPurple = Color(0xFF460063)
 
 val LightGreen = Color(0xFF6AFF6A)
 val LightRed = Color(0xFFFF6363)
+val TriviaGreen = Color(0xFF01BB09)
+val TriviaRed = Color(0xFFAB0000)

--- a/app/src/main/java/com/triviagenai/triviagen/ui/theme/Color.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/ui/theme/Color.kt
@@ -12,3 +12,6 @@ val Pink40 = Color(0xFF7D5260)
 
 val RoyalPurple = Color(0xFF5A0080)
 val DarkPurple = Color(0xFF460063)
+
+val LightGreen = Color(0xFF6AFF6A)
+val LightRed = Color(0xFFFF6363)

--- a/app/src/main/java/com/triviagenai/triviagen/ui/theme/Theme.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/ui/theme/Theme.kt
@@ -10,7 +10,7 @@ private val DarkColorScheme = darkColorScheme(
     primary = DarkPurple,
     secondary = PurpleGrey80,
     tertiary = Pink80,
-    background = RoyalPurple
+    background = RoyalPurple,
 )
 
 private val LightColorScheme = lightColorScheme(

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -14,4 +14,6 @@
     <dimen name="element_height">70dp</dimen>
 
     <dimen name="spacer_medium">50dp</dimen>
+    <dimen name="elevation_small">8dp</dimen>
+    <dimen name="border_width">1dp</dimen>
 </resources>


### PR DESCRIPTION
This PR has a rough navigation wired up which needs to be replaced by actual navigation. The implementation wires up the viewmodel with the various trivia screens.


https://github.com/sidcgithub/ai-trivia-app-android/assets/12014497/d3cf5ed4-6b8b-4347-a098-19012d57db36
