### PR TITLE
TRIVIAGEN-27: Retry reset state to loading

### DIFF
--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/TriviaQuestionViewModel.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/TriviaQuestionViewModel.kt
@@ -111,9 +111,14 @@ class TriviaQuestionViewModel @Inject constructor(
             isOptionButtonEnabled = true
         }
     }
+
+    fun reset() {
+        _uiState.value = TriviaUIState.Loading
+    }
 }
 
 sealed class TriviaIntent {
-    data class SubmitAnswer(val selectedOptionIndex: Int, val navController: NavHostController) : TriviaIntent()
+    data class SubmitAnswer(val selectedOptionIndex: Int) : TriviaIntent()
+
     object RandomTriviaRound : TriviaIntent()
 }

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/results/ResultsScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/results/ResultsScreen.kt
@@ -45,6 +45,7 @@ fun ResultsScreen(
             is TriviaUIState.Success -> {
                 mutableFloatStateOf((state.value as TriviaUIState.Success).score.toFloat())
             }
+
             else -> {
                 mutableFloatStateOf(0f)
             }
@@ -55,6 +56,7 @@ fun ResultsScreen(
             is TriviaUIState.Success -> {
                 mutableIntStateOf((state.value as TriviaUIState.Success).questions.size)
             }
+
             else -> {
                 mutableIntStateOf(0)
             }
@@ -95,7 +97,7 @@ fun ResultsScreen(
                 )
             }
 
-            NavigationButtons(navController)
+            NavigationButtons(navController, triviaQuestionViewModel)
         }
     }
 }

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/results/components/NavigationButtons.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/results/components/NavigationButtons.kt
@@ -15,18 +15,25 @@ import androidx.navigation.NavHostController
 import com.triviagenai.triviagen.R
 import com.triviagenai.triviagen.core.presentation.ButtonData
 import com.triviagenai.triviagen.core.presentation.navigation.Route
+import com.triviagenai.triviagen.trivia.presentation.TriviaQuestionViewModel
 import com.triviagenai.triviagen.ui.theme.RoyalPurple
 
 @Composable
-fun NavigationButtons(navController: NavHostController) {
+fun NavigationButtons(navController: NavHostController, viewModel: TriviaQuestionViewModel) {
     val buttonData = listOf(
         ButtonData(
             text = stringResource(R.string.retry),
-            onClick = { navController.navigate(Route.RoundSetupRoute) }
+            onClick = {
+                viewModel.reset()
+                navController.navigate(Route.RoundSetupRoute)
+            }
         ),
         ButtonData(
             text = stringResource(R.string.home),
-            onClick = { navController.navigate(Route.MainMenuRoute) }
+            onClick = {
+                viewModel.reset()
+                navController.navigate(Route.MainMenuRoute)
+            }
         )
     )
 

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/components/DisplayGameContent.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/components/DisplayGameContent.kt
@@ -42,19 +42,25 @@ fun DisplayGameContent(
     val questionBlock =
         (triviaRound as TriviaUIState.Success).questions[(triviaRound).currentQuestionIndex]
 
-    val borderColors: (correctAnswerColor: Color, wrongAnswerColor: Color, optionColor: Color, index: Int) -> Color = { correctAnswerColor, wrongAnswerColor, optionColor, index ->
-        if(index == questionBlock.answer && questionBlock.selectedAnswer != SelectedAnswerState.Unanswered)
-            correctAnswerColor
-        else if(selectedIndex == index && questionBlock.selectedAnswer != SelectedAnswerState.Unanswered)
-            wrongAnswerColor
-        else
-            optionColor
-    }
+    val borderColors: (correctAnswerColor: Color, wrongAnswerColor: Color, optionColor: Color, index: Int) -> Color =
+        { correctAnswerColor, wrongAnswerColor, optionColor, index ->
+            if (index == questionBlock.answer && questionBlock.selectedAnswer != SelectedAnswerState.Unanswered)
+                correctAnswerColor
+            else if (selectedIndex == index && questionBlock.selectedAnswer != SelectedAnswerState.Unanswered)
+                wrongAnswerColor
+            else
+                optionColor
+        }
 
-    LaunchedEffect(triviaRound.questions.size, triviaRound.currentQuestionIndex, questionBlock.selectedAnswer) {
+    LaunchedEffect(
+        triviaRound.questions.size,
+        triviaRound.currentQuestionIndex,
+        questionBlock.selectedAnswer
+    ) {
         if (triviaRound.questions.isNotEmpty() &&
             triviaRound.questions.size - 1 == triviaRound.currentQuestionIndex &&
-            questionBlock.selectedAnswer != SelectedAnswerState.Unanswered) {
+            questionBlock.selectedAnswer != SelectedAnswerState.Unanswered
+        ) {
             navController.navigate(Route.ResultsRoute) {
                 popUpTo(Route.TriviaGameRoute) {
                     inclusive = true
@@ -66,8 +72,7 @@ fun DisplayGameContent(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .testTag("TriviaGameScreen")
-        ,
+            .testTag("TriviaGameScreen"),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
@@ -80,10 +85,7 @@ fun DisplayGameContent(
                 onClick = {
                     setSelectedIndex(index)
                     viewModel.processIntent(
-                        TriviaIntent.SubmitAnswer(
-                            index,
-                            navController
-                        )
+                        TriviaIntent.SubmitAnswer(index)
                     )
                 },
                 shape = AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner)),
@@ -91,16 +93,16 @@ fun DisplayGameContent(
                     .padding(dimensionResource(id = R.dimen.padding_small))
                     .width(dimensionResource(id = R.dimen.element_xlarge))
                     .border(
-                        width = if(questionBlock.selectedAnswer != SelectedAnswerState.Unanswered && (index == questionBlock.answer || selectedIndex == index)) 2.dp else 1.dp,
+                        width = if (questionBlock.selectedAnswer != SelectedAnswerState.Unanswered && (index == questionBlock.answer || selectedIndex == index)) 2.dp else 1.dp,
                         color = borderColors(TriviaGreen, TriviaRed, Color.Gray, index),
                         shape = AbsoluteRoundedCornerShape(dimensionResource(id = R.dimen.rounded_corner))
                     )
                     .shadow(
                         elevation = dimensionResource(id = R.dimen.elevation_small),
                         ambientColor =
-                            borderColors(LightGreen, LightRed, Color.Transparent, index),
+                        borderColors(LightGreen, LightRed, Color.Transparent, index),
                         spotColor =
-                            borderColors(TriviaGreen, TriviaRed, Color.Gray, index)
+                        borderColors(TriviaGreen, TriviaRed, Color.Gray, index)
                     ),
                 enabled = viewModel.isOptionButtonEnabled,
                 colors = ButtonDefaults.buttonColors(


### PR DESCRIPTION
The PR addresses a bug where on retrying a round the round would be skipped and directly go to the results screen. The bug was addressed by resetting to loading state.


https://github.com/sidcgithub/ai-trivia-app-android/assets/12014497/5abd4583-e452-48b9-b22c-ebc6c407d639

