### PR TITLE
TRIVIAGEN-16: Quit button in game screen

### DIFF
--- a/app/src/androidTest/java/com/triviagenai/triviagen/NavigationTest.kt
+++ b/app/src/androidTest/java/com/triviagenai/triviagen/NavigationTest.kt
@@ -58,4 +58,36 @@ class NavigationTest {
             .onNodeWithTag("TriviaGameScreen")
             .assertIsDisplayed()
     }
+
+    @Test
+    fun navigation_clickTopBarBackButtonInTriviaGameScreen_navigatesToRoundSetupScreen() {
+        composeTestRule
+            .onNodeWithText("Quick game")
+            .performClick()
+
+        composeTestRule
+            .onNodeWithTag("RandomRoundButton")
+            .performClick()
+
+        composeTestRule
+            .onNodeWithTag("TopAppBarBackNavigationButton")
+            .performClick()
+
+        composeTestRule
+            .onNodeWithTag("QuitTriviaAlertDialogConfirmButton")
+            .performClick()
+
+        composeTestRule
+            .onNodeWithTag("RoundSetupScreen")
+            .assertIsDisplayed()
+
+        composeTestRule
+            .activityRule.scenario.onActivity { activity ->
+                activity.onBackPressedDispatcher.onBackPressed()
+            }
+
+        composeTestRule
+            .onNodeWithTag("MainMenuScreen")
+            .assertIsDisplayed()
+    }
 }

--- a/app/src/main/java/com/triviagenai/triviagen/core/presentation/TriviaGenScaffold.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/core/presentation/TriviaGenScaffold.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -40,6 +41,7 @@ fun TriviaGenScaffold(
                             onClick = {
                                 navigationStatus.backNav()
                             },
+                            modifier = Modifier.testTag("TopAppBarBackNavigationButton")
                         ) {
                             Icon(
                                 imageVector = Icons.Default.ArrowBack,

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/TriviaGameScreen.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/TriviaGameScreen.kt
@@ -1,5 +1,6 @@
 package com.triviagenai.triviagen.trivia.presentation.triviagame
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Text
@@ -7,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -18,6 +20,7 @@ import com.triviagenai.triviagen.core.presentation.navigation.NavigationStatus
 import com.triviagenai.triviagen.trivia.presentation.TriviaQuestionViewModel
 import com.triviagenai.triviagen.trivia.presentation.TriviaUIState
 import com.triviagenai.triviagen.trivia.presentation.triviagame.components.DisplayGameContent
+import com.triviagenai.triviagen.trivia.presentation.triviagame.components.QuitTriviaAlertDialog
 
 @Composable
 fun TriviaGameScreen(
@@ -27,9 +30,22 @@ fun TriviaGameScreen(
     val modifier = Modifier.testTag("TriviaGameScreen")
     val triviaRound by triviaQuestionViewModel.uiState.collectAsState()
     var selectedIndex by remember { mutableIntStateOf(-1) }
+    val isShowingExitDialog = remember { mutableStateOf(false) }
     TriviaGenScaffold(
-        navigationStatus = NavigationStatus.None
+        navigationStatus = NavigationStatus.Enabled(
+            navController = navController,
+            backNav = { isShowingExitDialog.value = true }
+        )
     ) {
+        QuitTriviaAlertDialog(
+            isShowingExitDialog,
+            navController
+        )
+
+        BackHandler {
+            isShowingExitDialog.value = true
+        }
+
         when (triviaRound) {
             is TriviaUIState.Success -> DisplayGameContent(
                 triviaRound,

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/components/QuitTriviaAlertDialog.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/components/QuitTriviaAlertDialog.kt
@@ -1,0 +1,52 @@
+package com.triviagenai.triviagen.trivia.presentation.triviagame.components
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavController
+import com.triviagenai.triviagen.R
+import com.triviagenai.triviagen.core.presentation.navigation.Route
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun QuitTriviaAlertDialog(
+    isShowingExitDialog: MutableState<Boolean>,
+    navController: NavController
+) {
+    if (isShowingExitDialog.value) {
+        AlertDialog(
+            onDismissRequest = { isShowingExitDialog.value = false },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        isShowingExitDialog.value = false
+                        navController.navigateUp()
+                    },
+                ) {
+                    Text(text = stringResource(R.string.yes))
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { isShowingExitDialog.value = false },
+                    modifier = Modifier.padding(horizontal = dimensionResource(id = R.dimen.padding_medium))
+                ) {
+                    Text(text = stringResource(R.string.no))
+                }
+            },
+            text = {
+                Text(text = stringResource(R.string.do_you_really_want_to_leave_a_trivia))
+            },
+            title = {
+                Text(text = stringResource(R.string.leaving_a_trivia))
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/components/QuitTriviaAlertDialog.kt
+++ b/app/src/main/java/com/triviagenai/triviagen/trivia/presentation/triviagame/components/QuitTriviaAlertDialog.kt
@@ -2,19 +2,17 @@ package com.triviagenai.triviagen.trivia.presentation.triviagame.components
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavController
 import com.triviagenai.triviagen.R
-import com.triviagenai.triviagen.core.presentation.navigation.Route
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun QuitTriviaAlertDialog(
     isShowingExitDialog: MutableState<Boolean>,
@@ -29,6 +27,7 @@ fun QuitTriviaAlertDialog(
                         isShowingExitDialog.value = false
                         navController.navigateUp()
                     },
+                    modifier = Modifier.testTag("QuitTriviaAlertDialogConfirmButton")
                 ) {
                     Text(text = stringResource(R.string.yes))
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,4 +12,8 @@
     <string name="retry">Retry</string>
     <string name="trivia_topic">Trivia topic</string>
     <string name="dark_theme">Dark theme</string>
+    <string name="do_you_really_want_to_leave_a_trivia">Do you really want to leave a trivia?</string>
+    <string name="leaving_a_trivia">Leaving a trivia</string>
+    <string name="yes">Yes</string>
+    <string name="no">No</string>
 </resources>


### PR DESCRIPTION
I have implemented quit button in TriviaGameScreen, so now user can leave the game. Also there is handling hardware back button, and both top app bar back button and hardware back button display alert dialog after click. When user leave one trivia after answering to question, and then starting new trivia, the results of first trivia won't affect second trivia's results. Also I wrote one simple test.

[Screen_recording_20240711_133723.webm](https://github.com/sidcgithub/ai-trivia-app-android/assets/91783342/1930ff2a-9a8e-4af5-b7e4-f60347914dae)
